### PR TITLE
Moving GarbageCollectionNotificationInfo into its own public class

### DIFF
--- a/stats/src/main/java/com/facebook/airlift/stats/JmxGcMonitor.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/JmxGcMonitor.java
@@ -14,8 +14,6 @@
 package com.facebook.airlift.stats;
 
 import com.facebook.airlift.log.Logger;
-import com.google.common.collect.ImmutableMap;
-import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -28,19 +26,12 @@ import javax.management.Notification;
 import javax.management.NotificationListener;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
-import javax.management.openmbean.TabularData;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryUsage;
-import java.util.Collection;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.Math.max;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -156,113 +147,6 @@ public class JmxGcMonitor
                         info.getBeforeGcTotal(),
                         info.getAfterGcTotal());
             }
-        }
-    }
-
-    private static class GarbageCollectionNotificationInfo
-    {
-        // these are well known constants used by all known OpenJDK GCs
-        private static final String MINOR_GC_NAME = "end of minor GC";
-        private static final String MAJOR_GC_NAME = "end of major GC";
-
-        private final String gcName;
-        private final String gcAction;
-        private final String gcCause;
-
-        private final long startTime;
-        private final long endTime;
-        private final Map<String, MemoryUsage> usageBeforeGc;
-        private final Map<String, MemoryUsage> usageAfterGc;
-
-        GarbageCollectionNotificationInfo(CompositeData compositeData)
-        {
-            requireNonNull(compositeData, "compositeData is null");
-            this.gcName = (String) compositeData.get("gcName");
-            this.gcAction = (String) compositeData.get("gcAction");
-            this.gcCause = (String) compositeData.get("gcCause");
-
-            CompositeData gcInfo = (CompositeData) compositeData.get("gcInfo");
-            this.startTime = (Long) gcInfo.get("startTime");
-            this.endTime = (Long) gcInfo.get("endTime");
-            this.usageBeforeGc = extractMemoryUsageMap(gcInfo, "memoryUsageBeforeGc");
-            this.usageAfterGc = extractMemoryUsageMap(gcInfo, "memoryUsageAfterGc");
-        }
-
-        public long getStartTime()
-        {
-            return startTime;
-        }
-
-        public long getEndTime()
-        {
-            return endTime;
-        }
-
-        public long getDurationMs()
-        {
-            return max(0, this.endTime - this.startTime);
-        }
-
-        public Map<String, MemoryUsage> getMemoryUsageBeforeGc()
-        {
-            return usageBeforeGc;
-        }
-
-        public Map<String, MemoryUsage> getMemoryUsageAfterGc()
-        {
-            return usageAfterGc;
-        }
-
-        private DataSize getBeforeGcTotal()
-        {
-            return totalMemorySize(getMemoryUsageBeforeGc());
-        }
-
-        private DataSize getAfterGcTotal()
-        {
-            return totalMemorySize(getMemoryUsageAfterGc());
-        }
-
-        public boolean isMinorGc()
-        {
-            return gcAction.equalsIgnoreCase(MINOR_GC_NAME);
-        }
-
-        public boolean isMajorGc()
-        {
-            return gcAction.equalsIgnoreCase(MAJOR_GC_NAME);
-        }
-
-        @Override
-        public String toString()
-        {
-            return toStringHelper(this)
-                    .add("gcName", gcName)
-                    .add("gcAction", gcAction)
-                    .add("gcCause", gcCause)
-                    .add("durationMs", getDurationMs())
-                    .add("beforeGcMb", getBeforeGcTotal())
-                    .add("afterGcMb", getAfterGcTotal())
-                    .toString();
-        }
-
-        private static DataSize totalMemorySize(Map<String, MemoryUsage> memUsages)
-        {
-            long bytes = 0;
-            for (MemoryUsage memoryUsage : memUsages.values()) {
-                bytes += memoryUsage.getUsed();
-            }
-            return succinctBytes(bytes);
-        }
-
-        private static Map<String, MemoryUsage> extractMemoryUsageMap(CompositeData compositeData, String attributeName)
-        {
-            ImmutableMap.Builder<String, MemoryUsage> map = ImmutableMap.builder();
-            TabularData tabularData = (TabularData) compositeData.get(attributeName);
-            for (CompositeData entry : (Collection<CompositeData>) tabularData.values()) {
-                map.put((String) entry.get("key"), MemoryUsage.from((CompositeData) entry.get("value")));
-            }
-            return map.build();
         }
     }
 }

--- a/stats/src/main/java/io/airlift/stats/GarbageCollectionNotificationInfo.java
+++ b/stats/src/main/java/io/airlift/stats/GarbageCollectionNotificationInfo.java
@@ -1,0 +1,123 @@
+package com.facebook.airlift.stats;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.TabularData;
+
+import java.lang.management.MemoryUsage;
+import java.util.Collection;
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.units.DataSize.succinctBytes;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+
+public class GarbageCollectionNotificationInfo
+{
+    // these are well known constants used by all known OpenJDK GCs
+    private static final String MINOR_GC_NAME = "end of minor GC";
+    private static final String MAJOR_GC_NAME = "end of major GC";
+
+    private final String gcName;
+    private final String gcAction;
+    private final String gcCause;
+
+    private final long startTime;
+    private final long endTime;
+    private final Map<String, MemoryUsage> usageBeforeGc;
+    private final Map<String, MemoryUsage> usageAfterGc;
+
+    public GarbageCollectionNotificationInfo(CompositeData compositeData)
+    {
+        requireNonNull(compositeData, "compositeData is null");
+        this.gcName = (String) compositeData.get("gcName");
+        this.gcAction = (String) compositeData.get("gcAction");
+        this.gcCause = (String) compositeData.get("gcCause");
+
+        CompositeData gcInfo = (CompositeData) compositeData.get("gcInfo");
+        this.startTime = (Long) gcInfo.get("startTime");
+        this.endTime = (Long) gcInfo.get("endTime");
+        this.usageBeforeGc = extractMemoryUsageMap(gcInfo, "memoryUsageBeforeGc");
+        this.usageAfterGc = extractMemoryUsageMap(gcInfo, "memoryUsageAfterGc");
+    }
+
+    public long getStartTime()
+    {
+        return startTime;
+    }
+
+    public long getEndTime()
+    {
+        return endTime;
+    }
+
+    public long getDurationMs()
+    {
+        return max(0, this.endTime - this.startTime);
+    }
+
+    public Map<String, MemoryUsage> getMemoryUsageBeforeGc()
+    {
+        return usageBeforeGc;
+    }
+
+    public Map<String, MemoryUsage> getMemoryUsageAfterGc()
+    {
+        return usageAfterGc;
+    }
+
+    public DataSize getBeforeGcTotal()
+    {
+        return totalMemorySize(getMemoryUsageBeforeGc());
+    }
+
+    public DataSize getAfterGcTotal()
+    {
+        return totalMemorySize(getMemoryUsageAfterGc());
+    }
+
+    public boolean isMinorGc()
+    {
+        return gcAction.equalsIgnoreCase(MINOR_GC_NAME);
+    }
+
+    public boolean isMajorGc()
+    {
+        return gcAction.equalsIgnoreCase(MAJOR_GC_NAME);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("gcName", gcName)
+                .add("gcAction", gcAction)
+                .add("gcCause", gcCause)
+                .add("durationMs", getDurationMs())
+                .add("beforeGcMb", getBeforeGcTotal())
+                .add("afterGcMb", getAfterGcTotal())
+                .toString();
+    }
+
+    private static DataSize totalMemorySize(Map<String, MemoryUsage> memUsages)
+    {
+        long bytes = 0;
+        for (MemoryUsage memoryUsage : memUsages.values()) {
+            bytes += memoryUsage.getUsed();
+        }
+        return succinctBytes(bytes);
+    }
+
+    private static Map<String, MemoryUsage> extractMemoryUsageMap(CompositeData compositeData, String attributeName)
+    {
+        ImmutableMap.Builder<String, MemoryUsage> map = ImmutableMap.builder();
+        TabularData tabularData = (TabularData) compositeData.get(attributeName);
+        for (CompositeData entry : (Collection<CompositeData>) tabularData.values()) {
+            map.put((String) entry.get("key"), MemoryUsage.from((CompositeData) entry.get("value")));
+        }
+        return map.build();
+    }
+}


### PR DESCRIPTION
In this diff we move `GarbageCollectionNotificationInfo` out from `JmxGcMonitor.java` into its own public class file.

This will allow other libraries to use the `GarbageCollectionNotificationInfo` object. The reason we want to do this is because clients of this repository should be allowed to read the GC messages provided from the JVM without using necessarily using `JmxGcMonitor`.  In such a world it seems to make sense to let the dependents of airlift to use the same GC notification parser as airlift to keep things both consistent and DRY. 

A concrete example of this that we will be doing is in Presto; we will add another GC listener to provided special logging during a Full GC. This logging is much more application specific than the logs provided in `JmxGcMonitor`