### PR TITLE
Update mysql version in dbpool

### DIFF
--- a/dbpool/src/main/java/com/facebook/airlift/dbpool/MySqlDataSource.java
+++ b/dbpool/src/main/java/com/facebook/airlift/dbpool/MySqlDataSource.java
@@ -17,7 +17,7 @@ package com.facebook.airlift.dbpool;
 
 import com.facebook.airlift.discovery.client.ServiceDescriptor;
 import com.facebook.airlift.discovery.client.ServiceSelector;
-import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
 
 import javax.sql.PooledConnection;
 

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.23</version>
+                <version>8.0.18</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
As part of a larger MySQL connector update in Presto, we also need to update dependencies.  Without this change, using this code in the later connector is not possible as it results in ClassNotFoundException.