### PR TITLE
Introduce ChunkedBytesContentProvider

### DIFF
--- a/http-client/src/main/java/com/facebook/airlift/http/client/jetty/ChunkedBytesContentProvider.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/jetty/ChunkedBytesContentProvider.java
@@ -1,0 +1,96 @@
+package com.facebook.airlift.http.client.jetty;
+
+import org.eclipse.jetty.client.util.AbstractTypedContentProvider;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+public class ChunkedBytesContentProvider
+        extends AbstractTypedContentProvider
+{
+    private static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+    private static final int DEFAULT_BUFFER_SIZE = 4096;
+
+    private final byte[] bytes;
+    private final int bufferSizeInBytes;
+
+    public ChunkedBytesContentProvider(byte[] bytes)
+    {
+        this(APPLICATION_OCTET_STREAM, bytes, DEFAULT_BUFFER_SIZE);
+    }
+
+    public ChunkedBytesContentProvider(byte[] bytes, int bufferSizeInBytes)
+    {
+        this(APPLICATION_OCTET_STREAM, bytes, bufferSizeInBytes);
+    }
+
+    public ChunkedBytesContentProvider(String contentType, byte[] bytes)
+    {
+        this(contentType, bytes, DEFAULT_BUFFER_SIZE);
+    }
+
+    public ChunkedBytesContentProvider(String contentType, byte[] bytes, int bufferSizeInBytes)
+    {
+        super(contentType);
+        this.bytes = requireNonNull(bytes, "bytes is null");
+        checkArgument(bufferSizeInBytes > 0, "bufferSizeInBytes must be greater than zero: %s", bufferSizeInBytes);
+        this.bufferSizeInBytes = bufferSizeInBytes;
+    }
+
+    @Override
+    public long getLength()
+    {
+        return bytes.length;
+    }
+
+    @Override
+    public boolean isReproducible()
+    {
+        return true;
+    }
+
+    @Override
+    public Iterator<ByteBuffer> iterator()
+    {
+        return new ChunkedIterator(bytes, bufferSizeInBytes);
+    }
+
+    private static class ChunkedIterator
+            implements Iterator<ByteBuffer>
+    {
+        private final ByteBuffer buffer;
+        private final int bufferSize;
+        private int index;
+
+        private ChunkedIterator(byte[] bytes, int bufferSize)
+        {
+            this.buffer = ByteBuffer.wrap(bytes);
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return index < buffer.capacity();
+        }
+
+        @Override
+        public ByteBuffer next()
+        {
+            if (index == buffer.capacity()) {
+                throw new NoSuchElementException();
+            }
+
+            int length = min(buffer.capacity() - index, bufferSize);
+            buffer.position(index);
+            buffer.limit(index + length);
+            index += length;
+            return buffer;
+        }
+    }
+}

--- a/http-client/src/test/java/com/facebook/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/com/facebook/airlift/http/client/AbstractHttpClientTest.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -467,8 +468,16 @@ public abstract class AbstractHttpClientTest
     public void testPutMethodWithStaticBodyGenerator()
             throws Exception
     {
+        testPutMethodWithStaticBodyGenerator(new byte[] {1, 2, 5});
+        byte[] largeBody = new byte[1024 * 1024];
+        ThreadLocalRandom.current().nextBytes(largeBody);
+        testPutMethodWithStaticBodyGenerator(largeBody);
+    }
+
+    public void testPutMethodWithStaticBodyGenerator(byte[] body)
+            throws Exception
+    {
         URI uri = baseURI.resolve("/road/to/nowhere");
-        byte[] body = {1, 2, 5};
         Request request = preparePut()
                 .setUri(uri)
                 .addHeader("foo", "bar")

--- a/http-client/src/test/java/com/facebook/airlift/http/client/jetty/TestChunkedBytesContentProvider.java
+++ b/http-client/src/test/java/com/facebook/airlift/http/client/jetty/TestChunkedBytesContentProvider.java
@@ -1,0 +1,71 @@
+package com.facebook.airlift.http.client.jetty;
+
+import org.eclipse.jetty.client.api.ContentProvider;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public class TestChunkedBytesContentProvider
+{
+    @Test
+    public void testGetLength()
+    {
+        ContentProvider contentProvider = new ChunkedBytesContentProvider(new byte[] {1, 2, 3});
+        assertEquals(contentProvider.getLength(), 3);
+        contentProvider = new ChunkedBytesContentProvider(new byte[] {});
+        assertEquals(contentProvider.getLength(), 0);
+    }
+
+    @Test
+    public void testIterator()
+    {
+        ContentProvider contentProvider = new ChunkedBytesContentProvider(new byte[] {}, 2);
+        Iterator<ByteBuffer> iterator = contentProvider.iterator();
+        assertFalse(iterator.hasNext());
+
+        contentProvider = new ChunkedBytesContentProvider(new byte[] {1}, 2);
+        iterator = contentProvider.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), ByteBuffer.wrap(new byte[] {1}));
+        assertFalse(iterator.hasNext());
+
+        contentProvider = new ChunkedBytesContentProvider(new byte[] {1, 2}, 2);
+        iterator = contentProvider.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), ByteBuffer.wrap(new byte[] {1, 2}));
+        assertFalse(iterator.hasNext());
+
+        contentProvider = new ChunkedBytesContentProvider(new byte[] {1, 2, 3}, 2);
+        iterator = contentProvider.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), ByteBuffer.wrap(new byte[] {1, 2}));
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), ByteBuffer.wrap(new byte[] {3}));
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testIsReproducible()
+    {
+        byte[] bytes = {1, 2, 3};
+        ContentProvider contentProvider = new ChunkedBytesContentProvider(bytes);
+        assertTrue(contentProvider.isReproducible());
+        Iterator<ByteBuffer> iterator = contentProvider.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), ByteBuffer.wrap(bytes));
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
+        iterator = contentProvider.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(iterator.next(), ByteBuffer.wrap(bytes));
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
+    }
+}


### PR DESCRIPTION
Jetty leverages NIO for sending the request. NIO channels accept native byte buffers
as an input that are futher fed to the operation system to be transferred.
In some cases HTTP requests can be as large as tens or even hundreeds of megabytes.
Allocating such large native buffers is not desirable, as it may cause native memory
spikes resulting in overall system instabillity.
ChunkedBytesContentProvider provides bytes request message is chunks.
Chunk size is selected based on the http-client.request-buffer-size config property,
that is equal to 4kb by default.