### PR TITLE
Revert "Update mysql version in dbpool"

### DIFF
--- a/dbpool/src/main/java/com/facebook/airlift/dbpool/MySqlDataSource.java
+++ b/dbpool/src/main/java/com/facebook/airlift/dbpool/MySqlDataSource.java
@@ -17,7 +17,7 @@ package com.facebook.airlift.dbpool;
 
 import com.facebook.airlift.discovery.client.ServiceDescriptor;
 import com.facebook.airlift.discovery.client.ServiceSelector;
-import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
+import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
 
 import javax.sql.PooledConnection;
 

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>8.0.18</version>
+                <version>5.1.23</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Reverts prestodb/airlift#8

We don't need this because the desired fix in MySQL 8 has already been backported to MySQL 5 drivers.

cc: @wenleix 