### PR TITLE
Add authorization support for HTTP endpoints

### DIFF
--- a/http-server/src/main/java/com/facebook/airlift/http/server/AuthorizationEnabledServlet.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/AuthorizationEnabledServlet.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.server;
+
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.security.RolesAllowed;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.Principal;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.airlift.http.server.HttpServerConfig.AuthorizationPolicy;
+import static com.google.common.io.ByteStreams.copy;
+import static com.google.common.io.ByteStreams.nullOutputStream;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class AuthorizationEnabledServlet
+        extends HttpServlet
+{
+    private final Servlet delegate;
+    private final Authorizer authorizer;
+    private final AuthorizationPolicy authorizationPolicy;
+    private final Set<String> defaultAllowedRoles;
+    private final Optional<Set<String>> allowedRoles;
+
+    public AuthorizationEnabledServlet(
+            Servlet delegate,
+            Authorizer authorizer,
+            AuthorizationPolicy authorizationPolicy,
+            Set<String> defaultAllowedRoles)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.authorizer = requireNonNull(authorizer, "authorizer is null");
+        this.authorizationPolicy = requireNonNull(authorizationPolicy, "authorizationPolicy is null");
+        this.defaultAllowedRoles = requireNonNull(defaultAllowedRoles, "defaultAllowedRoles is null");
+        this.allowedRoles = getRolesFromClassMetadata(delegate);
+    }
+
+    @Override
+    public void init()
+            throws ServletException
+    {
+        super.init();
+        delegate.init(this.getServletConfig());
+    }
+
+    @Override
+    public void service(ServletRequest req, ServletResponse res)
+            throws ServletException, IOException
+    {
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+
+        Principal principal = request.getUserPrincipal();
+        if (principal == null) {
+            abortWithMessage(request, response, "Request principal is missing.");
+            return;
+        }
+
+        Optional<Set<String>> allowedRoles = this.allowedRoles;
+        if (!allowedRoles.isPresent()) {
+            switch (authorizationPolicy) {
+                case ALLOW:
+                    delegate.service(req, res);
+                    return;
+                case DENY:
+                    abortWithMessage(request, response, format("Principal %s is not allowed to access the resource. Reason: denied by default policy",
+                            principal.getName()));
+                    return;
+                case DEFAULT_ROLES:
+                    allowedRoles = Optional.of(defaultAllowedRoles);
+                    break;
+                default:
+            }
+        }
+
+        AuthorizationResult result = authorizer.authorize(principal, allowedRoles.get());
+        if (!result.isAllowed()) {
+            abortWithMessage(request, response, format("Principal %s is not allowed to access the resource. Reason: %s",
+                    principal.getName(),
+                    result.getReason()));
+            return;
+        }
+        delegate.service(req, res);
+    }
+
+    private static void abortWithMessage(HttpServletRequest request, HttpServletResponse response, String message)
+            throws IOException
+    {
+        skipRequestBody(request);
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, format(message));
+    }
+
+    private static void skipRequestBody(HttpServletRequest request)
+            throws IOException
+    {
+        // If we send the challenge without consuming the body of the request,
+        // the server will close the connection after sending the response.
+        // The client may interpret this as a failed request and not resend the
+        // request with the authentication header. We can avoid this behavior
+        // in the client by reading and discarding the entire body of the
+        // unauthenticated request before sending the response.
+        try (InputStream inputStream = request.getInputStream()) {
+            copy(inputStream, nullOutputStream());
+        }
+    }
+
+    private static Optional<Set<String>> getRolesFromClassMetadata(Servlet servlet)
+    {
+        if (servlet.getClass().isAnnotationPresent(RolesAllowed.class)) {
+            return Optional.of(ImmutableSet.copyOf(servlet.getClass().getAnnotation(RolesAllowed.class).value()));
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+}

--- a/http-server/src/main/java/com/facebook/airlift/http/server/AuthorizationResult.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/AuthorizationResult.java
@@ -1,0 +1,35 @@
+package com.facebook.airlift.http.server;
+
+import static java.util.Objects.requireNonNull;
+
+public class AuthorizationResult
+{
+    private final boolean allowed;
+    private final String reason;
+
+    private AuthorizationResult(boolean allowed, String reason)
+    {
+        this.allowed = allowed;
+        this.reason = requireNonNull(reason, "reason is null");
+    }
+
+    public boolean isAllowed()
+    {
+        return allowed;
+    }
+
+    public String getReason()
+    {
+        return reason;
+    }
+
+    public static AuthorizationResult success()
+    {
+        return new AuthorizationResult(true, "");
+    }
+
+    public static AuthorizationResult failure(String reason)
+    {
+        return new AuthorizationResult(false, reason);
+    }
+}

--- a/http-server/src/main/java/com/facebook/airlift/http/server/Authorizer.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/Authorizer.java
@@ -1,0 +1,9 @@
+package com.facebook.airlift.http.server;
+
+import java.security.Principal;
+import java.util.Set;
+
+public interface Authorizer
+{
+    AuthorizationResult authorize(Principal principal, Set<String> allowedRoles);
+}

--- a/http-server/src/main/java/com/facebook/airlift/http/server/ConfigurationBasedAuthorizer.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/ConfigurationBasedAuthorizer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.server;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.Principal;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.facebook.airlift.http.server.AuthorizationResult.failure;
+import static com.facebook.airlift.http.server.AuthorizationResult.success;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Maps.fromProperties;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ConfigurationBasedAuthorizer
+        implements Authorizer
+{
+    private final Map<String, Pattern> roleRegexMap;
+
+    @Inject
+    public ConfigurationBasedAuthorizer(ConfigurationBasedAuthorizerConfig config)
+            throws IOException
+    {
+        this(config.getRoleMapFilePath());
+    }
+
+    @VisibleForTesting
+    public ConfigurationBasedAuthorizer(String roleMapFilePath)
+            throws IOException
+    {
+        requireNonNull(roleMapFilePath, "roleMapFilePath is null");
+        Properties properties = new Properties();
+        try (InputStream inputStream = new FileInputStream(roleMapFilePath)) {
+            properties.load(inputStream);
+        }
+        roleRegexMap = fromProperties(properties)
+                .entrySet()
+                .stream()
+                .collect(toImmutableMap(Map.Entry::getKey, e -> Pattern.compile(e.getValue())));
+    }
+
+    @Override
+    public AuthorizationResult authorize(Principal principal, Set<String> allowedRoles)
+    {
+        for (String role : allowedRoles) {
+            if (roleRegexMap.containsKey(role) && isPrincipalAuthorized(principal, roleRegexMap.get(role))) {
+                return success();
+            }
+        }
+        return failure(format("%s is not a member of the allowed roles: %s", principal.getName(), allowedRoles));
+    }
+
+    private boolean isPrincipalAuthorized(Principal principal, Pattern identityRegex)
+    {
+        return identityRegex.matcher(principal.getName()).matches();
+    }
+}

--- a/http-server/src/main/java/com/facebook/airlift/http/server/ConfigurationBasedAuthorizerConfig.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/ConfigurationBasedAuthorizerConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.server;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class ConfigurationBasedAuthorizerConfig
+{
+    private String roleMapFilePath;
+
+    @NotNull
+    public String getRoleMapFilePath()
+    {
+        return roleMapFilePath;
+    }
+
+    @Config("configuration-based-authorizer.role-regex-map.file-path")
+    public ConfigurationBasedAuthorizerConfig setRoleMapFilePath(String roleMapFilePath)
+    {
+        this.roleMapFilePath = roleMapFilePath;
+        return this;
+    }
+}

--- a/http-server/src/main/java/com/facebook/airlift/http/server/ConfigurationBasedAuthorizerModule.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/ConfigurationBasedAuthorizerModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.server;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class ConfigurationBasedAuthorizerModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(Authorizer.class).to(ConfigurationBasedAuthorizer.class);
+        configBinder(binder).bindConfig(ConfigurationBasedAuthorizerConfig.class);
+    }
+}

--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerProvider.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerProvider.java
@@ -59,6 +59,7 @@ public class HttpServerProvider
     private final Set<Filter> adminFilters;
     private TraceTokenManager traceTokenManager;
     private final EventClient eventClient;
+    private Authorizer authorizer;
 
     @Inject
     public HttpServerProvider(HttpServerInfo httpServerInfo,
@@ -131,6 +132,12 @@ public class HttpServerProvider
         this.traceTokenManager = tokenManager;
     }
 
+    @Inject(optional = true)
+    public void setAuthorizer(@Nullable Authorizer authorizer)
+    {
+        this.authorizer = authorizer;
+    }
+
     @Override
     public HttpServer get()
     {
@@ -150,7 +157,8 @@ public class HttpServerProvider
                     loginService,
                     traceTokenManager,
                     stats,
-                    eventClient);
+                    eventClient,
+                    authorizer);
             httpServer.start();
             return httpServer;
         }

--- a/http-server/src/main/java/com/facebook/airlift/http/server/testing/TestingHttpServer.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/testing/TestingHttpServer.java
@@ -16,6 +16,7 @@
 package com.facebook.airlift.http.server.testing;
 
 import com.facebook.airlift.event.client.NullEventClient;
+import com.facebook.airlift.http.server.Authorizer;
 import com.facebook.airlift.http.server.HttpServer;
 import com.facebook.airlift.http.server.HttpServerBinder.HttpResourceBinding;
 import com.facebook.airlift.http.server.HttpServerConfig;
@@ -25,14 +26,15 @@ import com.facebook.airlift.http.server.TheServlet;
 import com.facebook.airlift.node.NodeInfo;
 import com.facebook.airlift.tracetoken.TraceTokenManager;
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
 
-import javax.inject.Inject;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public class TestingHttpServer
@@ -46,7 +48,8 @@ public class TestingHttpServer
             HttpServerConfig config,
             @TheServlet Servlet servlet,
             @TheServlet Map<String, Servlet> servlets,
-            @TheServlet Map<String, String> initParameters)
+            @TheServlet Map<String, String> initParameters,
+            Optional<Authorizer> authorizer)
             throws IOException
     {
         this(httpServerInfo,
@@ -56,7 +59,8 @@ public class TestingHttpServer
                 servlets,
                 initParameters,
                 ImmutableSet.of(),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                authorizer);
     }
 
     @Inject
@@ -68,7 +72,8 @@ public class TestingHttpServer
             @TheServlet Map<String, Servlet> servlets,
             @TheServlet Map<String, String> initParameters,
             @TheServlet Set<Filter> filters,
-            @TheServlet Set<HttpResourceBinding> resources)
+            @TheServlet Set<HttpResourceBinding> resources,
+            Optional<Authorizer> authorizer)
             throws IOException
     {
         super(httpServerInfo,
@@ -86,7 +91,8 @@ public class TestingHttpServer
                 null,
                 new TraceTokenManager(),
                 new RequestStats(),
-                new NullEventClient());
+                new NullEventClient(),
+                authorizer.orElse(null));
         this.httpServerInfo = httpServerInfo;
     }
 

--- a/http-server/src/main/java/com/facebook/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/testing/TestingHttpServerModule.java
@@ -88,6 +88,5 @@ public class TestingHttpServerModule
     List<Authenticator> getAuthenticatorList(Set<Authenticator> authenticators)
     {
         return ImmutableList.copyOf(authenticators);
-        newOptionalBinder(binder, Authorizer.class);
     }
 }

--- a/http-server/src/main/java/com/facebook/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/testing/TestingHttpServerModule.java
@@ -18,6 +18,7 @@ package com.facebook.airlift.http.server.testing;
 import com.facebook.airlift.discovery.client.AnnouncementHttpServerInfo;
 import com.facebook.airlift.http.server.AuthenticationFilter;
 import com.facebook.airlift.http.server.Authenticator;
+import com.facebook.airlift.http.server.Authorizer;
 import com.facebook.airlift.http.server.HttpServer;
 import com.facebook.airlift.http.server.HttpServerConfig;
 import com.facebook.airlift.http.server.HttpServerInfo;
@@ -40,6 +41,7 @@ import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.http.server.HttpServerBinder.HttpResourceBinding;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 
 public class TestingHttpServerModule
         implements Module
@@ -79,11 +81,13 @@ public class TestingHttpServerModule
         newSetBinder(binder, Filter.class, TheServlet.class).addBinding()
                 .to(AuthenticationFilter.class).in(Scopes.SINGLETON);
         newSetBinder(binder, Authenticator.class);
+        newOptionalBinder(binder, Authorizer.class);
     }
 
     @Provides
     List<Authenticator> getAuthenticatorList(Set<Authenticator> authenticators)
     {
         return ImmutableList.copyOf(authenticators);
+        newOptionalBinder(binder, Authorizer.class);
     }
 }

--- a/http-server/src/test/java/com/facebook/airlift/http/server/TestAuthorizationEnabledServletInHttpServer.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/TestAuthorizationEnabledServletInHttpServer.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.server;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.StatusResponseHandler.StatusResponse;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.airlift.http.server.testing.TestingHttpServerModule;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.annotation.security.RolesAllowed;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.facebook.airlift.http.server.AuthorizationResult.failure;
+import static com.facebook.airlift.http.server.AuthorizationResult.success;
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static org.testng.Assert.assertEquals;
+
+public class TestAuthorizationEnabledServletInHttpServer
+{
+    private HttpClient client;
+
+    @BeforeClass
+    public void setup()
+    {
+        client = new JettyHttpClient();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(client);
+    }
+
+    @Test
+    public void testAuthDisabled()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.of("http-server.authorization.enabled", "false");
+        TestingHttpServer server = createServer(serverProperties);
+        server.start();
+        assertEquals(sendRequest(server, "unmarked").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequest(server, "user").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequest(server, "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "unmarked", "user").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "user", "user").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "admin", "user").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "unmarked", "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "user", "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "admin", "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        server.stop();
+    }
+
+    @Test
+    public void testDefaultPolicyAllow()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("http-server.authorization.enabled", "true")
+                .put("http-server.authorization.default-policy", "ALLOW")
+                .build();
+        TestingHttpServer server = createServer(serverProperties);
+        server.start();
+        assertEquals(sendRequest(server, "unmarked").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequest(server, "user").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequest(server, "admin").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "unmarked", "user").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "user", "user").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "admin", "user").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "unmarked", "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "user", "admin").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "admin", "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        server.stop();
+    }
+
+    @Test
+    public void testDefaultPolicyDeny()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("http-server.authorization.enabled", "true")
+                .put("http-server.authorization.default-policy", "DENY")
+                .build();
+        TestingHttpServer server = createServer(serverProperties);
+        server.start();
+        assertEquals(sendRequest(server, "unmarked").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequest(server, "user").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequest(server, "admin").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "unmarked", "user").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "user", "user").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "admin", "user").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "unmarked", "admin").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "user", "admin").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "admin", "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        server.stop();
+    }
+
+    @Test
+    public void testDefaultPolicyDefaultRoles()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("http-server.authorization.enabled", "true")
+                .put("http-server.authorization.default-policy", "DEFAULT_ROLES")
+                .put("http-server.authorization.default-allowed-roles", "internal, admin")
+                .build();
+        TestingHttpServer server = createServer(serverProperties);
+        server.start();
+        assertEquals(sendRequest(server, "unmarked").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequest(server, "user").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequest(server, "admin").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "unmarked", "user").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "user", "user").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "admin", "user").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "unmarked", "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "user", "admin").getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(sendRequestWithRole(server, "admin", "admin").getStatusCode(), Response.Status.OK.getStatusCode());
+        server.stop();
+    }
+
+    private StatusResponse sendRequest(TestingHttpServer server, String resource)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl()).appendPath(resource).build();
+        Request request = Request.Builder.prepareGet().setUri(uri).build();
+        return client.execute(request, createStatusResponseHandler());
+    }
+
+    private StatusResponse sendRequestWithRole(TestingHttpServer server, String resource, String role)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl()).appendPath(resource).build();
+        Request request = Request.Builder.prepareGet().setUri(uri).setHeader("ROLE", role).build();
+        return client.execute(request, createStatusResponseHandler());
+    }
+
+    private static class MockAuthorizer
+            implements Authorizer
+    {
+        @Override
+        public AuthorizationResult authorize(Principal principal, Set<String> allowedRoles)
+        {
+            for (String role : allowedRoles) {
+                if (role.equals(principal.getName())) {
+                    return success();
+                }
+            }
+            return failure("Not an allowed role");
+        }
+    }
+
+    private static class MockAuthenticationFilter
+            implements Filter
+    {
+        @Override
+        public void init(FilterConfig filterConfig)
+        {
+        }
+
+        @Override
+        public void destroy()
+        {
+        }
+
+        @Override
+        public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain nextFilter)
+                throws IOException, ServletException
+        {
+            HttpServletRequest request = (HttpServletRequest) servletRequest;
+            HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+            String role = request.getHeader("ROLE");
+            if (role != null) {
+                request = new HttpServletRequestWrapper(request)
+                {
+                    @Override
+                    public Principal getUserPrincipal()
+                    {
+                        return () -> role;
+                    }
+                };
+            }
+            nextFilter.doFilter(request, response);
+        }
+    }
+
+    public static class MockUnmarkedServlet
+            extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response)
+        {
+            response.setStatus(HttpServletResponse.SC_OK);
+        }
+    }
+
+    @RolesAllowed("user")
+    public static class MockUserServlet
+            extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response)
+        {
+            response.setStatus(HttpServletResponse.SC_OK);
+        }
+    }
+
+    @RolesAllowed("admin")
+    public static class MockAdminServlet
+            extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response)
+        {
+            response.setStatus(HttpServletResponse.SC_OK);
+        }
+    }
+
+    private static TestingHttpServer createServer(Map<String, String> serverProperties)
+    {
+        List<Module> modules = ImmutableList.<Module>builder()
+                .add(new TestingNodeModule())
+                .add(new TestingHttpServerModule())
+                .add(new Module()
+                {
+                    @Override
+                    public void configure(Binder binder)
+                    {
+                        binder.bind(Servlet.class).annotatedWith(TheServlet.class).to(DummyServlet.class);
+                        newSetBinder(binder, Filter.class, TheServlet.class).addBinding()
+                                .to(MockAuthenticationFilter.class).in(Scopes.SINGLETON);
+                        newMapBinder(binder, String.class, Servlet.class, TheServlet.class)
+                                .addBinding("/unmarked/*")
+                                .to(MockUnmarkedServlet.class)
+                                .in(Scopes.SINGLETON);
+                        newMapBinder(binder, String.class, Servlet.class, TheServlet.class)
+                                .addBinding("/user/*")
+                                .to(MockUserServlet.class)
+                                .in(Scopes.SINGLETON);
+                        newMapBinder(binder, String.class, Servlet.class, TheServlet.class)
+                                .addBinding("/admin/*")
+                                .to(MockAdminServlet.class)
+                                .in(Scopes.SINGLETON);
+                    }
+
+                    @Provides
+                    @TheServlet
+                    public Map<String, String> createTheServletParams()
+                    {
+                        return new HashMap<>();
+                    }
+                })
+                .add(installModuleIf(
+                        HttpServerConfig.class,
+                        HttpServerConfig::isAuthorizationEnabled,
+                        binder -> binder.bind(Authorizer.class).to(MockAuthorizer.class)))
+                .build();
+
+        return new Bootstrap(modules)
+                .strictConfig()
+                .doNotInitializeLogging()
+                .setOptionalConfigurationProperties(serverProperties)
+                .quiet()
+                .initialize()
+                .getInstance(TestingHttpServer.class);
+    }
+}

--- a/http-server/src/test/java/com/facebook/airlift/http/server/TestConfigurationBasedAuthorizer.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/TestConfigurationBasedAuthorizer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.server;
+
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestConfigurationBasedAuthorizer
+{
+    @Test
+    public void testAuthorize()
+            throws IOException
+    {
+        Authorizer authorizer = new ConfigurationBasedAuthorizer("src/test/resources/roles.properties");
+        assertTrue(authorizer.authorize(() -> "tom", ImmutableSet.of("user")).isAllowed());
+        assertTrue(authorizer.authorize(() -> "jerry", ImmutableSet.of("user")).isAllowed());
+        assertFalse(authorizer.authorize(() -> "jacob", ImmutableSet.of("user")).isAllowed());
+        assertTrue(authorizer.authorize(() -> "jacob", ImmutableSet.of("admin")).isAllowed());
+        assertFalse(authorizer.authorize(() -> "foo.bar", ImmutableSet.of("service")).isAllowed());
+        assertTrue(authorizer.authorize(() -> "gateway.airlift", ImmutableSet.of("service")).isAllowed());
+        assertTrue(authorizer.authorize(() -> "logger.airlift", ImmutableSet.of("service")).isAllowed());
+    }
+}

--- a/http-server/src/test/java/com/facebook/airlift/http/server/TestConfigurationBasedAuthorizerConfig.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/TestConfigurationBasedAuthorizerConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.server;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+
+public class TestConfigurationBasedAuthorizerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(ConfigAssertions.recordDefaults(ConfigurationBasedAuthorizerConfig.class)
+                .setRoleMapFilePath(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("configuration-based-authorizer.role-regex-map.file-path", "roles.properties")
+                .build();
+
+        ConfigurationBasedAuthorizerConfig expected = new ConfigurationBasedAuthorizerConfig()
+                .setRoleMapFilePath("roles.properties");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/http-server/src/test/java/com/facebook/airlift/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/TestHttpServerConfig.java
@@ -83,7 +83,10 @@ public class TestHttpServerConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(8, KILOBYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(16, MEGABYTE))
-                .setHttp2StreamIdleTimeout(new Duration(15, SECONDS)));
+                .setHttp2StreamIdleTimeout(new Duration(15, SECONDS))
+                .setAuthorizationEnabled(false)
+                .setDefaultAuthorizationPolicy(HttpServerConfig.AuthorizationPolicy.ALLOW)
+                .setDefaultAllowedRoles(""));
     }
 
     @Test
@@ -135,6 +138,9 @@ public class TestHttpServerConfig
                 .put("http-server.http2.stream-receive-window-size", "4MB")
                 .put("http-server.http2.input-buffer-size", "4MB")
                 .put("http-server.http2.stream-idle-timeout", "23s")
+                .put("http-server.authorization.enabled", "true")
+                .put("http-server.authorization.default-policy", "DENY")
+                .put("http-server.authorization.default-allowed-roles", "user, internal, admin")
                 .build();
 
         HttpServerConfig expected = new HttpServerConfig()
@@ -182,7 +188,10 @@ public class TestHttpServerConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(4, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(4, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(4, MEGABYTE))
-                .setHttp2StreamIdleTimeout(new Duration(23, SECONDS));
+                .setHttp2StreamIdleTimeout(new Duration(23, SECONDS))
+                .setAuthorizationEnabled(true)
+                .setDefaultAuthorizationPolicy(HttpServerConfig.AuthorizationPolicy.DENY)
+                .setDefaultAllowedRoles("user, internal, admin");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/http-server/src/test/java/com/facebook/airlift/http/server/testing/TestTestingHttpServer.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/testing/TestTestingHttpServer.java
@@ -55,6 +55,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
@@ -274,7 +275,7 @@ public class TestTestingHttpServer
         NodeInfo nodeInfo = new NodeInfo("test");
         HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
         HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
-        return new TestingHttpServer(httpServerInfo, nodeInfo, config, servlet, ImmutableMap.of(), params);
+        return new TestingHttpServer(httpServerInfo, nodeInfo, config, servlet, ImmutableMap.of(), params, Optional.empty());
     }
 
     private static TestingHttpServer createTestingHttpServerWithFilter(DummyServlet servlet, Map<String, String> params, DummyFilter filter)
@@ -283,7 +284,7 @@ public class TestTestingHttpServer
         NodeInfo nodeInfo = new NodeInfo("test");
         HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
         HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
-        return new TestingHttpServer(httpServerInfo, nodeInfo, config, servlet, ImmutableMap.of(), params, ImmutableSet.of(filter), ImmutableSet.of());
+        return new TestingHttpServer(httpServerInfo, nodeInfo, config, servlet, ImmutableMap.of(), params, ImmutableSet.of(filter), ImmutableSet.of(), Optional.empty());
     }
 
     static class DummyServlet

--- a/http-server/src/test/resources/roles.properties
+++ b/http-server/src/test/resources/roles.properties
@@ -1,0 +1,3 @@
+user=tom|jerry
+admin=jacob
+service=([^\\.]*)\\.airlift

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -42,8 +42,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/AuthorizationFilter.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/AuthorizationFilter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs;
+
+import com.facebook.airlift.http.server.AuthorizationResult;
+import com.facebook.airlift.http.server.Authorizer;
+import com.facebook.airlift.http.server.HttpServerConfig;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import java.security.Principal;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.airlift.http.server.HttpServerConfig.AuthorizationPolicy;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+@Provider
+public class AuthorizationFilter
+        implements ContainerRequestFilter
+{
+    private final Authorizer authorizer;
+    private final AuthorizationPolicy authorizationPolicy;
+    private final Set<String> defaultAllowedRoles;
+
+    @Context
+    private ResourceInfo resourceInfo;
+
+    @Inject
+    public AuthorizationFilter(Authorizer authorizer, HttpServerConfig httpServerConfig)
+    {
+        this(
+                authorizer,
+                httpServerConfig.getDefaultAuthorizationPolicy(),
+                httpServerConfig.getDefaultAllowedRoles());
+    }
+
+    @VisibleForTesting
+    public AuthorizationFilter(
+            Authorizer authorizer,
+            AuthorizationPolicy authorizationPolicy,
+            Set<String> defaultAllowedRoles)
+    {
+        this.authorizer = requireNonNull(authorizer, "authorizer is null");
+        this.authorizationPolicy = requireNonNull(authorizationPolicy, "authorizationPolicy is null");
+        this.defaultAllowedRoles = requireNonNull(defaultAllowedRoles, "defaultAllowedRoles is null");
+    }
+
+    @Override
+    public void filter(ContainerRequestContext request)
+    {
+        Principal principal = request.getSecurityContext().getUserPrincipal();
+        if (principal == null) {
+            request.abortWith(Response.status(Response.Status.FORBIDDEN)
+                    .entity("Request principal is missing.")
+                    .build());
+            return;
+        }
+
+        Optional<Set<String>> allowedRoles = getAllowedRoles();
+        if (!allowedRoles.isPresent()) {
+            switch (authorizationPolicy) {
+                case ALLOW:
+                    return;
+                case DENY:
+                    request.abortWith(Response.status(Response.Status.FORBIDDEN)
+                            .entity(format("Principal %s is not allowed to access the resource. Reason: denied by default policy",
+                                    principal.getName()))
+                            .build());
+                    return;
+                case DEFAULT_ROLES:
+                    allowedRoles = Optional.of(defaultAllowedRoles);
+                    break;
+                default:
+            }
+        }
+
+        AuthorizationResult result = authorizer.authorize(principal, allowedRoles.get());
+        if (!result.isAllowed()) {
+            request.abortWith(Response.status(Response.Status.FORBIDDEN)
+                    .entity(format("Principal %s is not allowed to access the resource. Reason: %s",
+                            principal.getName(),
+                            result.getReason()))
+                    .build());
+        }
+    }
+
+    private Optional<Set<String>> getAllowedRoles()
+    {
+        // Checking method level annotation for roles (overrides the class level annotation if exists)
+        if (resourceInfo.getResourceMethod().isAnnotationPresent(RolesAllowed.class)) {
+            return Optional.of(ImmutableSet.copyOf(resourceInfo.getResourceMethod().getAnnotation(RolesAllowed.class).value()));
+        }
+        // Checking class level annotation for roles
+        else if (resourceInfo.getResourceClass().isAnnotationPresent(RolesAllowed.class)) {
+            return Optional.of(ImmutableSet.copyOf(resourceInfo.getResourceClass().getAnnotation(RolesAllowed.class).value()));
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+}

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/JaxrsModule.java
@@ -15,11 +15,12 @@
  */
 package com.facebook.airlift.jaxrs;
 
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.airlift.http.server.HttpServerConfig;
 import com.facebook.airlift.http.server.TheServlet;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Key;
-import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -38,7 +39,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
 public class JaxrsModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     public JaxrsModule() {}
 
@@ -49,7 +50,7 @@ public class JaxrsModule
     }
 
     @Override
-    public void configure(Binder binder)
+    protected void setup(Binder binder)
     {
         binder.disableCircularProxies();
 
@@ -59,6 +60,10 @@ public class JaxrsModule
         jaxrsBinder(binder).bind(SmileMapper.class);
         jaxrsBinder(binder).bind(ParsingExceptionMapper.class);
         jaxrsBinder(binder).bind(OverrideMethodFilter.class);
+
+        if (buildConfigObject(HttpServerConfig.class).isAuthorizationEnabled()) {
+            jaxrsBinder(binder).bind(AuthorizationFilter.class);
+        }
 
         newSetBinder(binder, Object.class, JaxrsResource.class).permitDuplicates();
     }

--- a/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestAuthorizationFilterInHttpServer.java
+++ b/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestAuthorizationFilterInHttpServer.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.StatusResponseHandler.StatusResponse;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.airlift.http.server.AuthorizationResult;
+import com.facebook.airlift.http.server.Authorizer;
+import com.facebook.airlift.http.server.HttpServerConfig;
+import com.facebook.airlift.http.server.TheServlet;
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.airlift.http.server.testing.TestingHttpServerModule;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.annotation.security.RolesAllowed;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.facebook.airlift.http.server.AuthorizationResult.failure;
+import static com.facebook.airlift.http.server.AuthorizationResult.success;
+import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static org.testng.Assert.assertEquals;
+
+public class TestAuthorizationFilterInHttpServer
+{
+    private HttpClient client;
+
+    @BeforeClass
+    public void setup()
+    {
+        client = new JettyHttpClient();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(client);
+    }
+
+    @Test
+    public void testAuthDisabled()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.of("http-server.authorization.enabled", "false");
+        TestingHttpServer server = createServer(serverProperties);
+        server.start();
+        StatusResponse responseUnauthorizedToUnmarkedResource = sendRequest(server, "unmarked");
+        StatusResponse responseUnauthorizedToUserResource = sendRequest(server, "user");
+        StatusResponse responseUnauthorizedToAdminResource = sendRequest(server, "admin");
+        StatusResponse responseUserToUnmarkedResource = sendRequestWithRole(server, "unmarked", "user");
+        StatusResponse responseUserToUserResource = sendRequestWithRole(server, "user", "user");
+        StatusResponse responseUserToAdminResource = sendRequestWithRole(server, "admin", "user");
+        StatusResponse responseAdminToUnmarkedResource = sendRequestWithRole(server, "unmarked", "admin");
+        StatusResponse responseAdminToUserResource = sendRequestWithRole(server, "user", "admin");
+        StatusResponse responseAdminToAdminResource = sendRequestWithRole(server, "admin", "admin");
+        server.stop();
+
+        assertEquals(responseUnauthorizedToUnmarkedResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUnauthorizedToUserResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUnauthorizedToAdminResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUserToUnmarkedResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUserToUserResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUserToAdminResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseAdminToUnmarkedResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseAdminToUserResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseAdminToAdminResource.getStatusCode(), Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testDefaultPolicyAllow()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("http-server.authorization.enabled", "true")
+                .put("http-server.authorization.default-policy", "ALLOW")
+                .build();
+        TestingHttpServer server = createServer(serverProperties);
+        StatusResponse responseUnauthorizedToUnmarkedResource = sendRequest(server, "unmarked");
+        StatusResponse responseUnauthorizedToUserResource = sendRequest(server, "user");
+        StatusResponse responseUnauthorizedToAdminResource = sendRequest(server, "admin");
+        StatusResponse responseUserToUnmarkedResource = sendRequestWithRole(server, "unmarked", "user");
+        StatusResponse responseUserToUserResource = sendRequestWithRole(server, "user", "user");
+        StatusResponse responseUserToAdminResource = sendRequestWithRole(server, "admin", "user");
+        StatusResponse responseAdminToUnmarkedResource = sendRequestWithRole(server, "unmarked", "admin");
+        StatusResponse responseAdminToUserResource = sendRequestWithRole(server, "user", "admin");
+        StatusResponse responseAdminToAdminResource = sendRequestWithRole(server, "admin", "admin");
+        server.stop();
+
+        assertEquals(responseUnauthorizedToUnmarkedResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUnauthorizedToUserResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUnauthorizedToAdminResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUserToUnmarkedResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUserToUserResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUserToAdminResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseAdminToUnmarkedResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseAdminToUserResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseAdminToAdminResource.getStatusCode(), Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testDefaultPolicyDeny()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("http-server.authorization.enabled", "true")
+                .put("http-server.authorization.default-policy", "DENY")
+                .build();
+        TestingHttpServer server = createServer(serverProperties);
+        StatusResponse responseUnauthorizedToUnmarkedResource = sendRequest(server, "unmarked");
+        StatusResponse responseUnauthorizedToUserResource = sendRequest(server, "user");
+        StatusResponse responseUnauthorizedToAdminResource = sendRequest(server, "admin");
+        StatusResponse responseUserToUnmarkedResource = sendRequestWithRole(server, "unmarked", "user");
+        StatusResponse responseUserToUserResource = sendRequestWithRole(server, "user", "user");
+        StatusResponse responseUserToAdminResource = sendRequestWithRole(server, "admin", "user");
+        StatusResponse responseAdminToUnmarkedResource = sendRequestWithRole(server, "unmarked", "admin");
+        StatusResponse responseAdminToUserResource = sendRequestWithRole(server, "user", "admin");
+        StatusResponse responseAdminToAdminResource = sendRequestWithRole(server, "admin", "admin");
+        server.stop();
+
+        assertEquals(responseUnauthorizedToUnmarkedResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUnauthorizedToUserResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUnauthorizedToAdminResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUserToUnmarkedResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUserToUserResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUserToAdminResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseAdminToUnmarkedResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseAdminToUserResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseAdminToAdminResource.getStatusCode(), Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testDefaultPolicyDefaultRoles()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("http-server.authorization.enabled", "true")
+                .put("http-server.authorization.default-policy", "DEFAULT_ROLES")
+                .put("http-server.authorization.default-allowed-roles", "internal, admin")
+                .build();
+        TestingHttpServer server = createServer(serverProperties);
+        StatusResponse responseUnauthorizedToUnmarkedResource = sendRequest(server, "unmarked");
+        StatusResponse responseUnauthorizedToUserResource = sendRequest(server, "user");
+        StatusResponse responseUnauthorizedToAdminResource = sendRequest(server, "admin");
+        StatusResponse responseUserToUnmarkedResource = sendRequestWithRole(server, "unmarked", "user");
+        StatusResponse responseUserToUserResource = sendRequestWithRole(server, "user", "user");
+        StatusResponse responseUserToAdminResource = sendRequestWithRole(server, "admin", "user");
+        StatusResponse responseAdminToUnmarkedResource = sendRequestWithRole(server, "unmarked", "admin");
+        StatusResponse responseAdminToUserResource = sendRequestWithRole(server, "user", "admin");
+        StatusResponse responseAdminToAdminResource = sendRequestWithRole(server, "admin", "admin");
+        server.stop();
+
+        assertEquals(responseUnauthorizedToUnmarkedResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUnauthorizedToUserResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUnauthorizedToAdminResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUserToUnmarkedResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUserToUserResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseUserToAdminResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseAdminToUnmarkedResource.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseAdminToUserResource.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseAdminToAdminResource.getStatusCode(), Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testClassLevelRoles()
+            throws Exception
+    {
+        Map<String, String> serverProperties = ImmutableMap.of("http-server.authorization.enabled", "true");
+        TestingHttpServer server = createServer(serverProperties);
+        server.start();
+        StatusResponse responseUnauthorized = sendRequest(server, "class");
+        StatusResponse responseUser = sendRequestWithRole(server, "class", "user");
+        StatusResponse responseAdmin = sendRequestWithRole(server, "class", "admin");
+        server.stop();
+
+        assertEquals(responseUnauthorized.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+        assertEquals(responseUser.getStatusCode(), Response.Status.OK.getStatusCode());
+        assertEquals(responseAdmin.getStatusCode(), Response.Status.FORBIDDEN.getStatusCode());
+    }
+
+    private StatusResponse sendRequest(TestingHttpServer server, String resource)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl()).appendPath(resource).build();
+        Request request = Request.Builder.prepareGet().setUri(uri).build();
+        return client.execute(request, createStatusResponseHandler());
+    }
+
+    private StatusResponse sendRequestWithRole(TestingHttpServer server, String resource, String role)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl()).appendPath(resource).build();
+        Request request = Request.Builder.prepareGet().setUri(uri).setHeader("ROLE", role).build();
+        return client.execute(request, createStatusResponseHandler());
+    }
+
+    private static class MockAuthorizer
+            implements Authorizer
+    {
+        @Override
+        public AuthorizationResult authorize(Principal principal, Set<String> allowedRoles)
+        {
+            for (String role : allowedRoles) {
+                if (role.equals(principal.getName())) {
+                    return success();
+                }
+            }
+            return failure("Not an allowed role");
+        }
+    }
+
+    private static class MockAuthenticationFilter
+            implements Filter
+    {
+        @Override
+        public void init(FilterConfig filterConfig)
+        {
+        }
+
+        @Override
+        public void destroy()
+        {
+        }
+
+        @Override
+        public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain nextFilter)
+                throws IOException, ServletException
+        {
+            HttpServletRequest request = (HttpServletRequest) servletRequest;
+            HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+            String role = request.getHeader("ROLE");
+            if (role != null) {
+                request = new HttpServletRequestWrapper(request)
+                {
+                    @Override
+                    public Principal getUserPrincipal()
+                    {
+                        return () -> role;
+                    }
+                };
+            }
+            nextFilter.doFilter(request, response);
+        }
+    }
+
+    @Path("/")
+    public static class MockResource
+    {
+        @GET
+        @Path("unmarked")
+        public boolean unmarkedResource()
+        {
+            return true;
+        }
+
+        @GET
+        @Path("user")
+        @RolesAllowed("user")
+        public boolean userResource()
+        {
+            return true;
+        }
+
+        @GET
+        @Path("admin")
+        @RolesAllowed("admin")
+        public boolean adminResource()
+        {
+            return true;
+        }
+    }
+
+    @Path("/class")
+    @RolesAllowed("user")
+    public static class MockClassLevelResource
+    {
+        @GET
+        public boolean classResource()
+        {
+            return true;
+        }
+    }
+
+    private static TestingHttpServer createServer(Map<String, String> serverProperties)
+    {
+        List<Module> modules = ImmutableList.<Module>builder()
+                .add(new TestingNodeModule())
+                .add(new JaxrsModule())
+                .add(new JsonModule())
+                .add(new TestingHttpServerModule())
+                .add(binder -> {
+                    jaxrsBinder(binder).bind(MockResource.class);
+                    jaxrsBinder(binder).bind(MockClassLevelResource.class);
+                })
+                .add(installModuleIf(
+                        HttpServerConfig.class,
+                        HttpServerConfig::isAuthorizationEnabled,
+                        binder -> binder.bind(Authorizer.class).to(MockAuthorizer.class).in(Scopes.SINGLETON)))
+                .add(binder -> newSetBinder(binder, Filter.class, TheServlet.class).addBinding()
+                        .to(MockAuthenticationFilter.class).in(Scopes.SINGLETON))
+                .build();
+
+        return new Bootstrap(modules)
+                .strictConfig()
+                .doNotInitializeLogging()
+                .setOptionalConfigurationProperties(serverProperties)
+                .quiet()
+                .initialize()
+                .getInstance(TestingHttpServer.class);
+    }
+}


### PR DESCRIPTION
Partially implements: prestodb/presto [#14639](https://github.com/prestodb/presto/issues/14639)

Changes include:
1. Add authorization support for internal Jersey resources
2. Add authorization support for Jetty Servlets
3. Add a configuration based authorizer
4. Update corresponding tests