### PR TITLE
ThriftMapper for Thrift encoding/decoding over HTTP

### DIFF
--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -136,6 +136,21 @@
             <artifactId>failsafe</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-protocol</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-transport-netty</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/TInputStreamTransport.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/TInputStreamTransport.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.client.thrift;
+
+import com.facebook.drift.protocol.TTransport;
+import com.facebook.drift.protocol.TTransportException;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.util.Objects.requireNonNull;
+
+@NotThreadSafe
+public class TInputStreamTransport
+        implements TTransport
+{
+    private final InputStream inputStream;
+
+    public TInputStreamTransport(InputStream inputStream)
+    {
+        this.inputStream = requireNonNull(inputStream, "inputStream is null");
+    }
+
+    @Override
+    public void read(byte[] buf, int off, int len)
+            throws TTransportException
+    {
+        try {
+            inputStream.read(buf, off, len);
+        }
+        catch (IOException e) {
+            throw new TTransportException(e);
+        }
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/TOutputStreamTransport.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/TOutputStreamTransport.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.client.thrift;
+
+import com.facebook.drift.protocol.TTransport;
+import com.facebook.drift.protocol.TTransportException;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static java.util.Objects.requireNonNull;
+
+@NotThreadSafe
+public class TOutputStreamTransport
+        implements TTransport
+{
+    private final OutputStream outputStream;
+
+    public TOutputStreamTransport(OutputStream outputStream)
+    {
+        this.outputStream = requireNonNull(outputStream, "outputStream is null");
+    }
+
+    @Override
+    public void read(byte[] buf, int off, int len)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len)
+            throws TTransportException
+    {
+        try {
+            outputStream.write(buf, off, len);
+        }
+        catch (IOException e) {
+            throw new TTransportException(e);
+        }
+    }
+}

--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftBodyGenerator.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftBodyGenerator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.client.thrift;
+
+import com.facebook.airlift.http.client.BodyGenerator;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.transport.netty.codec.Protocol;
+
+import java.io.OutputStream;
+
+import static java.util.Objects.requireNonNull;
+
+public class ThriftBodyGenerator<T>
+        implements BodyGenerator
+{
+    private final T instance;
+    private final ThriftCodec<T> thriftCodec;
+    private final Protocol protocol;
+
+    public ThriftBodyGenerator(T instance, ThriftCodec<T> thriftCodec, Protocol protocol)
+    {
+        this.instance = requireNonNull(instance, "instance is null");
+        this.thriftCodec = requireNonNull(thriftCodec, "thriftCodec is null");
+        this.protocol = requireNonNull(protocol, "protocol is null");
+    }
+
+    @Override
+    public void write(OutputStream out)
+            throws Exception
+    {
+        ThriftProtocolUtils.write(instance, thriftCodec, protocol, out);
+    }
+}

--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftProtocolException.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftProtocolException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.client.thrift;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public class ThriftProtocolException
+        extends IOException
+{
+    private final Class<?> type;
+
+    public ThriftProtocolException(Class<?> type, Throwable cause)
+    {
+        super("Invalid thrift object for Java type " + requireNonNull(type, "type is null").getName(), cause);
+        this.type = type;
+    }
+
+    /**
+     * Returns the type of object that failed Thrift .
+     */
+    public Class<?> getType()
+    {
+        return type;
+    }
+}

--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftProtocolUtils.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftProtocolUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.client.thrift;
+
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.transport.netty.codec.Protocol;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class ThriftProtocolUtils
+{
+    private ThriftProtocolUtils()
+    {
+    }
+
+    public static <T> void write(T instance, ThriftCodec<T> thriftCodec, Protocol protocol, OutputStream output)
+            throws ThriftProtocolException
+    {
+        try {
+            thriftCodec.write(instance, protocol.createProtocol(new TOutputStreamTransport(output)));
+        }
+        catch (Exception e) {
+            throw new ThriftProtocolException(thriftCodec.getType().getJavaType().getClass(), e);
+        }
+    }
+
+    public static <T> T read(ThriftCodec<T> thriftCodec, Protocol protocol, InputStream input)
+            throws ThriftProtocolException
+    {
+        try {
+            return thriftCodec.read(protocol.createProtocol(new TInputStreamTransport(input)));
+        }
+        catch (Exception e) {
+            throw new ThriftProtocolException(thriftCodec.getType().getJavaType().getClass(), e);
+        }
+    }
+}

--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftRequestUtils.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftRequestUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.client.thrift;
+
+import com.facebook.airlift.http.client.Request;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.transport.netty.codec.Protocol;
+import com.google.common.net.MediaType;
+
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.google.common.net.HttpHeaders.ACCEPT;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+
+public class ThriftRequestUtils
+{
+    private static final MediaType THRIFT_TYPE = MediaType.create("application", "x-thrift");
+    private static final String TYPE_BINARY = THRIFT_TYPE.withParameter("t", Protocol.BINARY.name()).toString().toLowerCase();
+    private static final String TYPE_COMPACT = THRIFT_TYPE.withParameter("t", Protocol.COMPACT.name()).toString().toLowerCase();
+    private static final String TYPE_FBCOMPACT = THRIFT_TYPE.withParameter("t", Protocol.FB_COMPACT.name()).toString().toLowerCase();
+
+    private ThriftRequestUtils() {}
+
+    public static Request.Builder prepareThriftPost(Protocol protocol)
+    {
+        String type = getType(protocol);
+        return preparePost()
+                .setHeader(ACCEPT, type)
+                .setHeader(CONTENT_TYPE, type);
+    }
+
+    public static <T> Request.Builder prepareThriftPost(Protocol protocol, T instance, ThriftCodec<T> thriftCodec)
+    {
+        return prepareThriftPost(protocol)
+                .setBodyGenerator(createThriftBodyGenerator(instance, thriftCodec, protocol));
+    }
+
+    public static Request.Builder prepareThriftGet(Protocol protocol)
+    {
+        String type = getType(protocol);
+        return prepareGet()
+                .setHeader(ACCEPT, type)
+                .setHeader(CONTENT_TYPE, type);
+    }
+
+    private static <T> ThriftBodyGenerator<T> createThriftBodyGenerator(T instance, ThriftCodec<T> thriftCodec, Protocol protocol)
+    {
+        return new ThriftBodyGenerator<>(instance, thriftCodec, protocol);
+    }
+
+    private static String getType(Protocol protocol)
+    {
+        switch (protocol) {
+            case BINARY:
+                return TYPE_BINARY;
+            case COMPACT:
+                return TYPE_COMPACT;
+            case FB_COMPACT:
+                return TYPE_FBCOMPACT;
+            default:
+                throw new IllegalArgumentException("Invalid thrift protocol");
+        }
+    }
+}

--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftResponseHandler.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftResponseHandler.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.http.client.thrift;
+
+import com.facebook.airlift.http.client.HeaderName;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.Response;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.http.client.ResponseHandlerUtils;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.transport.netty.codec.Protocol;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.net.MediaType;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static java.util.Objects.requireNonNull;
+
+public class ThriftResponseHandler<T>
+        implements ResponseHandler<ThriftResponseHandler.ThriftResponse, RuntimeException>
+{
+    private final ThriftCodec<T> thriftCodec;
+
+    public ThriftResponseHandler(ThriftCodec<T> thriftCodec)
+    {
+        this.thriftCodec = requireNonNull(thriftCodec, "thriftCodec is null");
+    }
+
+    @Override
+    public ThriftResponse handleException(Request request, Exception exception)
+    {
+        throw ResponseHandlerUtils.propagate(request, exception);
+    }
+
+    @Override
+    public ThriftResponse handle(Request request, Response response)
+    {
+        T value = null;
+        IllegalArgumentException exception = null;
+        try {
+            Protocol protocol = getThriftProtocol(response.getHeaders());
+            value = ThriftProtocolUtils.read(thriftCodec, protocol, response.getInputStream());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        catch (Exception e) {
+            exception = new IllegalArgumentException("Unable to create " + thriftCodec.getType() + " from THRIFT response", e);
+        }
+        return new ThriftResponse(response.getStatusCode(), response.getStatusMessage(), response.getHeaders(), value, exception);
+    }
+
+    private Protocol getThriftProtocol(ListMultimap<HeaderName, String> headers)
+    {
+        HeaderName contentTypeHeader = HeaderName.of(CONTENT_TYPE);
+        if (!headers.containsKey(contentTypeHeader) || headers.get(contentTypeHeader).size() != 1) {
+            throw new IllegalArgumentException("Invalid response. Unable to create " + thriftCodec.getType() + " from THRIFT response");
+        }
+
+        ImmutableListMultimap<String, String> parameters = MediaType.parse(headers.get(contentTypeHeader).get(0)).parameters();
+
+        if (!parameters.containsKey("t") || parameters.get("t").size() != 1) {
+            throw new IllegalArgumentException("Invalid response. Unable to create " + thriftCodec.getType() + " from THRIFT response");
+        }
+
+        return Protocol.valueOf(parameters.get("t").get(0).toUpperCase());
+    }
+
+    public class ThriftResponse
+    {
+        private final int statusCode;
+        private final String statusMessage;
+        private final ListMultimap<HeaderName, String> headers;
+        private final T value;
+        private final IllegalArgumentException exception;
+
+        ThriftResponse(int statusCode, String statusMessage, ListMultimap<HeaderName, String> headers, T value, IllegalArgumentException exception)
+        {
+            this.statusCode = requireNonNull(statusCode, "statusCode is null");
+            this.statusMessage = requireNonNull(statusMessage, "statusMessage is null");
+            this.headers = headers != null ? ImmutableListMultimap.copyOf(headers) : null;
+            this.value = value;
+            this.exception = exception;
+        }
+
+        public int getStatusCode()
+        {
+            return statusCode;
+        }
+
+        public String getStatusMessage()
+        {
+            return statusMessage;
+        }
+
+        public T getValue()
+        {
+            return value;
+        }
+
+        @Nullable
+        public String getHeader(String name)
+        {
+            List<String> values = getHeaders().get(HeaderName.of(name));
+            return values.isEmpty() ? null : values.get(0);
+        }
+
+        public List<String> getHeaders(String name)
+        {
+            return headers.get(HeaderName.of(name));
+        }
+
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return headers;
+        }
+
+        public IllegalArgumentException getException()
+        {
+            return exception;
+        }
+    }
+}

--- a/jaxrs-testing/pom.xml
+++ b/jaxrs-testing/pom.xml
@@ -57,11 +57,34 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-transport-netty</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>jaxrs</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
 </project>

--- a/jaxrs-testing/src/test/java/com/facebook/airlift/jaxrs/testing/TestJaxrsThriftTestingHttpProcessor.java
+++ b/jaxrs-testing/src/test/java/com/facebook/airlift/jaxrs/testing/TestJaxrsThriftTestingHttpProcessor.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs.testing;
+
+import com.facebook.airlift.http.client.HttpStatus;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.testing.TestingHttpClient;
+import com.facebook.airlift.http.client.thrift.ThriftBodyGenerator;
+import com.facebook.airlift.http.client.thrift.ThriftResponseHandler;
+import com.facebook.airlift.jaxrs.thrift.ThriftMapper;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
+import com.facebook.drift.transport.netty.codec.Protocol;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import java.net.URI;
+
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.prepareThriftGet;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.prepareThriftPost;
+import static com.facebook.drift.transport.netty.codec.Protocol.BINARY;
+import static com.facebook.drift.transport.netty.codec.Protocol.COMPACT;
+import static com.facebook.drift.transport.netty.codec.Protocol.FB_COMPACT;
+import static com.google.common.net.HttpHeaders.ACCEPT;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+@Test
+public class TestJaxrsThriftTestingHttpProcessor
+{
+    private ThriftCodecManager codecManager;
+    private TestingHttpClient httpCient;
+    private ThriftCodec<TestThriftMessage> testThriftMessageThriftCodec;
+    private ThriftResponseHandler<TestThriftMessage> testThriftMessageTestThriftResponseHandler;
+
+    @BeforeClass
+    public void setup()
+    {
+        codecManager = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+        httpCient =
+                new TestingHttpClient(new JaxrsTestingHttpProcessor(URI.create("http://fake.invalid/"), new GetItResource(), new ThriftMapper(codecManager)));
+        testThriftMessageThriftCodec = codecManager.getCodec(TestThriftMessage.class);
+        testThriftMessageTestThriftResponseHandler = new ThriftResponseHandler<>(testThriftMessageThriftCodec);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        codecManager = null;
+        httpCient = null;
+        testThriftMessageThriftCodec = null;
+        testThriftMessageTestThriftResponseHandler = null;
+    }
+
+    @Test
+    public void testPostCompact()
+    {
+        Request request = prepareThriftPost(COMPACT, new TestThriftMessage("xyz", 1), testThriftMessageThriftCodec)
+                .setUri(URI.create("http://fake.invalid/http-thrift/post/2"))
+                .build();
+
+        ThriftResponseHandler.ThriftResponse response = httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+
+        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
+        assertTrue(response.getValue() instanceof TestThriftMessage);
+        assertEquals(((TestThriftMessage) response.getValue()).getTestString(), "xyz");
+        assertEquals(((TestThriftMessage) response.getValue()).getTestLong(), 3);
+    }
+
+    @Test
+    public void testPostBinary()
+    {
+        Request request = prepareThriftPost(BINARY, new TestThriftMessage("xyz", 1), testThriftMessageThriftCodec)
+                .setUri(URI.create("http://fake.invalid/http-thrift/post/2"))
+                .build();
+
+        ThriftResponseHandler.ThriftResponse response = httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+
+        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
+        assertTrue(response.getValue() instanceof TestThriftMessage);
+        assertEquals(((TestThriftMessage) response.getValue()).getTestString(), "xyz");
+        assertEquals(((TestThriftMessage) response.getValue()).getTestLong(), 3);
+    }
+
+    @Test
+    public void testPostFBCompact()
+    {
+        Request request = prepareThriftPost(FB_COMPACT, new TestThriftMessage("xyz", 1), testThriftMessageThriftCodec)
+                .setUri(URI.create("http://fake.invalid/http-thrift/post/2"))
+                .build();
+
+        ThriftResponseHandler.ThriftResponse response = httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+
+        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
+        assertTrue(response.getValue() instanceof TestThriftMessage);
+        assertEquals(((TestThriftMessage) response.getValue()).getTestString(), "xyz");
+        assertEquals(((TestThriftMessage) response.getValue()).getTestLong(), 3);
+    }
+
+    @Test
+    public void testGetCompact()
+    {
+        Request request = prepareThriftGet(COMPACT)
+                .setUri(URI.create("http://fake.invalid/http-thrift/get/2"))
+                .build();
+
+        ThriftResponseHandler.ThriftResponse response = httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+
+        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
+        assertTrue(response.getValue() instanceof TestThriftMessage);
+        assertEquals(((TestThriftMessage) response.getValue()).getTestString(), "abc");
+        assertEquals(((TestThriftMessage) response.getValue()).getTestLong(), 2);
+    }
+
+    @Test
+    public void testGetBinary()
+    {
+        Request request = prepareThriftGet(BINARY)
+                .setUri(URI.create("http://fake.invalid/http-thrift/get/2"))
+                .build();
+
+        ThriftResponseHandler.ThriftResponse response = httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+
+        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
+        assertTrue(response.getValue() instanceof TestThriftMessage);
+        assertEquals(((TestThriftMessage) response.getValue()).getTestString(), "abc");
+        assertEquals(((TestThriftMessage) response.getValue()).getTestLong(), 2);
+    }
+
+    @Test
+    public void testGetFBCompact()
+    {
+        Request request = prepareThriftGet(FB_COMPACT)
+                .setUri(URI.create("http://fake.invalid/http-thrift/get/2"))
+                .build();
+
+        ThriftResponseHandler.ThriftResponse response = httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+
+        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
+        assertTrue(response.getValue() instanceof TestThriftMessage);
+        assertEquals(((TestThriftMessage) response.getValue()).getTestString(), "abc");
+        assertEquals(((TestThriftMessage) response.getValue()).getTestLong(), 2);
+    }
+
+    @Test
+    public void testInvalidFormat()
+    {
+        Request request = preparePost()
+                .setHeader(ACCEPT, "application/x-thrift; t=nonbinary")
+                .setHeader(CONTENT_TYPE, "application/x-thrift")
+                .setBodyGenerator(createThriftBodyGenerator(COMPACT))
+                .setUri(URI.create("http://fake.invalid/http-thrift/post/2"))
+                .build();
+        try {
+            ThriftResponseHandler.ThriftResponse response = httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+            fail("expected exception");
+        }
+        catch (Exception e) {
+            assertEquals(e.getMessage(), "com.facebook.airlift.jaxrs.thrift.ThriftMapperParsingException: " +
+                    "Invalid thrift input for Java type class com.facebook.airlift.jaxrs.testing.TestThriftMessage");
+        }
+    }
+
+    private ThriftBodyGenerator createThriftBodyGenerator(Protocol protocol)
+    {
+        return new ThriftBodyGenerator(new TestThriftMessage("xyz", 1), testThriftMessageThriftCodec, protocol);
+    }
+
+    @Test
+    public void testException()
+    {
+        Request request = prepareGet()
+                .setUri(URI.create("http://fake.invalid/http-thrift/fail/testException"))
+                .build();
+
+        try {
+            httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+            fail("expected exception");
+        }
+        catch (TestingException e) {
+            assertEquals(e.getMessage(), "testException");
+        }
+    }
+
+    @Test
+    public void testUndefinedResource()
+    {
+        Request request = prepareGet()
+                .setUri(URI.create("http://fake.invalid/unknown"))
+                .build();
+
+        ThriftResponseHandler.ThriftResponse response = httpCient.execute(request, testThriftMessageTestThriftResponseHandler);
+        assertEquals(response.getStatusCode(), 404);
+    }
+
+    @Path("http-thrift")
+    public static class GetItResource
+    {
+        @Path("get/{id}")
+        @GET
+        @Produces("application/x-thrift")
+        public TestThriftMessage getTestThriftMessage(@PathParam("id") long id)
+        {
+            return new TestThriftMessage("abc", id);
+        }
+
+        @Path("post/{id}")
+        @POST
+        @Consumes("application/x-thrift")
+        @Produces("application/x-thrift")
+        public TestThriftMessage postTestThriftMessage(@PathParam("id") long id, TestThriftMessage testThriftMessage)
+        {
+            return new TestThriftMessage(testThriftMessage.getTestString(), id + testThriftMessage.getTestLong());
+        }
+
+        @Path("fail/{message}")
+        @GET
+        @Consumes("application/x-thrift")
+        @Produces("application/x-thrift")
+        public TestThriftMessage fail(@PathParam("message") String errorMessage)
+        {
+            throw new TestingException(errorMessage);
+        }
+    }
+
+    private static class TestingException
+            extends RuntimeException
+    {
+        public TestingException(String message)
+        {
+            super(message);
+        }
+    }
+}

--- a/jaxrs-testing/src/test/java/com/facebook/airlift/jaxrs/testing/TestThriftMessage.java
+++ b/jaxrs-testing/src/test/java/com/facebook/airlift/jaxrs/testing/TestThriftMessage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs.testing;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
+import static java.util.Objects.requireNonNull;
+
+@ThriftStruct
+public class TestThriftMessage
+{
+    private final String testString;
+    private final long testLong;
+
+    @ThriftConstructor
+    public TestThriftMessage(String testString, long testLong)
+    {
+        this.testString = requireNonNull(testString, "testString is null");
+        this.testLong = testLong;
+    }
+
+    @ThriftField(1)
+    public String getTestString()
+    {
+        return testString;
+    }
+
+    @ThriftField(2)
+    public long getTestLong()
+    {
+        return testLong;
+    }
+}

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -47,6 +47,26 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-protocol</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-transport-netty</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
@@ -119,6 +139,11 @@
             <artifactId>jackson-dataformat-smile</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.airlift</groupId>
@@ -138,11 +163,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.facebook.airlift</groupId>
-            <artifactId>http-client</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>
 

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/BaseMapper.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/BaseMapper.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs;
+
+import com.google.common.collect.ImmutableSet;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+// This code is based on JacksonJsonProvider
+public abstract class BaseMapper
+        implements MessageBodyReader<Object>, MessageBodyWriter<Object>
+{
+    /**
+     * Looks like we need to worry about accidental
+     * data binding for types we shouldn't be handling. This is
+     * probably not a very good way to do it, but let's start by
+     * blacklisting things we are not to handle.
+     */
+    private static final Set<Class<?>> IO_CLASSES = ImmutableSet.<Class<?>>builder()
+            .add(InputStream.class)
+            .add(java.io.Reader.class)
+            .add(OutputStream.class)
+            .add(java.io.Writer.class)
+            .add(byte[].class)
+            .add(char[].class)
+            .add(javax.ws.rs.core.StreamingOutput.class)
+            .add(Response.class)
+            .build();
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType)
+    {
+        return canReadOrWrite(type);
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType)
+    {
+        return canReadOrWrite(type);
+    }
+
+    private static boolean canReadOrWrite(Class<?> type)
+    {
+        if (IO_CLASSES.contains(type)) {
+            return false;
+        }
+        for (Class<?> ioClass : IO_CLASSES) {
+            if (ioClass.isAssignableFrom(type)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public long getSize(Object value, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType)
+    {
+        // In general figuring output size requires actual writing; usually not
+        // worth it to write everything twice.
+        return -1;
+    }
+}

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapper.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapper.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs.thrift;
+
+import com.facebook.airlift.http.client.thrift.ThriftProtocolException;
+import com.facebook.airlift.http.client.thrift.ThriftProtocolUtils;
+import com.facebook.airlift.jaxrs.BaseMapper;
+import com.facebook.airlift.log.Logger;
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.protocol.TTransportException;
+import com.facebook.drift.transport.netty.codec.Protocol;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+@Provider
+@Consumes("application/x-thrift")
+@Produces("application/x-thrift")
+public class ThriftMapper
+        extends BaseMapper
+{
+    public static final Logger log = Logger.get(ThriftMapper.class);
+
+    private final ThriftCodecManager thriftCodecManager;
+
+    @Inject
+    public ThriftMapper(ThriftCodecManager thriftCodecManager)
+    {
+        this.thriftCodecManager = requireNonNull(thriftCodecManager, "thriftCodecManager is null");
+    }
+
+    @Override
+    public Object readFrom(
+            Class<Object> type,
+            Type genericType,
+            Annotation[] annotations,
+            MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders,
+            InputStream inputStream)
+            throws IOException
+    {
+        try {
+            ThriftCodec<?> codec = thriftCodecManager.getCodec(genericType);
+            Object value = ThriftProtocolUtils.read(codec, getThriftProtocol(mediaType, codec), inputStream);
+            return value;
+        }
+        catch (Exception e) {
+            // we want to return a 400 for bad Thrift but not for a real IO exception
+            if (e instanceof IOException && !(e instanceof EOFException)) {
+                throw (IOException) e;
+            }
+            //The IOException is likely to be wrapped into a TTransportException
+            if (e instanceof TTransportException && e.getCause() instanceof IOException && !(e.getCause() instanceof EOFException)) {
+                throw (IOException) e.getCause();
+            }
+            // log the exception at debug so it can be viewed during development
+            // Note: we are not logging at a higher level because this could cause a denial of service
+            log.debug(e, "Invalid Thrift input for Java type %s", genericType);
+            // Invalid thrift request. Throwing exception so the response code can be overridden using a mapper.
+            throw new ThriftMapperParsingException(type, e);
+        }
+    }
+
+    @Override
+    public void writeTo(
+            Object value,
+            Class<?> type,
+            Type genericType,
+            Annotation[] annotations,
+            MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders,
+            OutputStream outputStream)
+            throws IOException
+    {
+        try {
+            ThriftCodec codec = thriftCodecManager.getCodec(type);
+            ThriftProtocolUtils.write(value, codec, getThriftProtocol(mediaType, codec), outputStream);
+        }
+        catch (Exception e) {
+            // handing EOFException same as JsonMapper
+            if (e instanceof EOFException || (e instanceof TTransportException && e.getCause() instanceof EOFException)) {
+                return;
+            }
+            log.debug(e, "Can not serialize to thrift for Java type %s", type);
+            if (e instanceof ThriftProtocolException) {
+                throw e;
+            }
+            throw new ThriftMapperParsingException(type, e);
+        }
+    }
+
+    private Protocol getThriftProtocol(MediaType mediaType, ThriftCodec<?> thriftCodec)
+    {
+        Map<String, String> parameters = mediaType.getParameters();
+
+        if (!parameters.containsKey("t")) {
+            throw new IllegalArgumentException("Invalid response. No protocol type specified. Unable to create " + thriftCodec.getType() + " from THRIFT response");
+        }
+        if (parameters.size() != 1) {
+            throw new IllegalArgumentException("Invalid response. Invalid parameter count:" + parameters.size() + " expected 1. Unable to create " + thriftCodec.getType() + " from THRIFT response");
+        }
+        return Protocol.valueOf(parameters.get("t").toUpperCase());
+    }
+}

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapperParsingException.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapperParsingException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs.thrift;
+
+import com.facebook.airlift.jaxrs.ParsingException;
+
+/**
+ * Wraps ThriftMapperParsingExceptions to provide more information about parsing errors.
+ */
+public class ThriftMapperParsingException
+        extends ParsingException
+{
+    private final Class<?> type;
+
+    public ThriftMapperParsingException(Class<?> type, Throwable cause)
+    {
+        super("Invalid thrift input for Java type " + type, cause);
+        this.type = type;
+    }
+
+    /**
+     * Returns the type of object that failed Thrift parsing.
+     */
+    public Class<?> getType()
+    {
+        return type;
+    }
+}

--- a/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestThriftMapper.java
+++ b/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestThriftMapper.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs;
+
+import com.facebook.airlift.jaxrs.testing.GuavaMultivaluedMap;
+import com.facebook.airlift.jaxrs.thrift.ThriftMapper;
+import com.facebook.airlift.jaxrs.thrift.ThriftMapperParsingException;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.zip.ZipException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestThriftMapper
+{
+    @Test
+    public void testSuccess()
+            throws IOException
+    {
+        assertRoundTrip(new TestThriftMessage("value1", 1));
+        assertRoundTrip(new TestThriftMessage("value2", 2));
+        assertRoundTrip(new TestThriftMessage("value3", 3));
+    }
+
+    private void assertRoundTrip(TestThriftMessage testThriftMessage)
+            throws IOException
+    {
+        ThriftCodecManager codecManager = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+        ThriftMapper thriftMapper = new ThriftMapper(codecManager);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        MultivaluedMap<String, Object> headers = new GuavaMultivaluedMap<>();
+        HashMap<String, String> parameters = new HashMap<>();
+        parameters.put("t", "binary");
+        MediaType mediaType = new MediaType("application", "x-thrift", parameters);
+        thriftMapper.writeTo(testThriftMessage, TestThriftMessage.class, null, null, mediaType, headers, outputStream);
+        TestThriftMessage readFrom = (TestThriftMessage) thriftMapper.readFrom(Object.class, TestThriftMessage.class, null, mediaType, null, new ByteArrayInputStream(outputStream.toByteArray()));
+        assertEquals(readFrom.getTestString(), testThriftMessage.getTestString());
+        assertEquals(readFrom.getTestLong(), testThriftMessage.getTestLong());
+    }
+
+    @Test
+    public void testEOFExceptionReturnsThriftMapperParsingException()
+            throws IOException
+    {
+        try {
+            ThriftCodecManager codecManager = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+            ThriftMapper thriftMapper = new ThriftMapper(codecManager);
+            thriftMapper.readFrom(Object.class, Object.class, null, null, null, new InputStream()
+            {
+                @Override
+                public int read()
+                        throws IOException
+                {
+                    throw new EOFException("forced EOF Exception");
+                }
+
+                @Override
+                public int read(byte[] b)
+                        throws IOException
+                {
+                    throw new EOFException("forced EOF Exception");
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len)
+                        throws IOException
+                {
+                    throw new EOFException("forced EOF Exception");
+                }
+            });
+            fail("Should have thrown a ThriftMapperParsingException");
+        }
+        catch (ThriftMapperParsingException e) {
+            assertTrue((e.getMessage()).startsWith("Invalid thrift input for Java type"));
+        }
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void testOtherIOExceptionThrowsIOException()
+            throws IOException
+    {
+        try {
+            ThriftCodecManager codecManager = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+            ThriftMapper thriftMapper = new ThriftMapper(codecManager);
+            thriftMapper.readFrom(Object.class, Object.class, null, null, null, new InputStream()
+            {
+                @Override
+                public int read()
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+
+                @Override
+                public int read(byte[] b)
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len)
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+            });
+            fail("Should have thrown an IOException");
+        }
+        catch (WebApplicationException e) {
+            fail("Should not have received a WebApplicationException", e);
+        }
+    }
+}

--- a/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestThriftMessage.java
+++ b/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestThriftMessage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.jaxrs;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
+import static java.util.Objects.requireNonNull;
+
+@ThriftStruct
+public class TestThriftMessage
+{
+    private final String testString;
+    private final long testLong;
+
+    @ThriftConstructor
+    public TestThriftMessage(String testString, long testLong)
+    {
+        this.testString = requireNonNull(testString, "testString is null");
+        this.testLong = testLong;
+    }
+
+    @ThriftField(1)
+    public String getTestString()
+    {
+        return testString;
+    }
+
+    @ThriftField(2)
+    public long getTestLong()
+    {
+        return testLong;
+    }
+}

--- a/jmx-http/pom.xml
+++ b/jmx-http/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>com.facebook.airlift</groupId>
@@ -93,12 +98,6 @@
         <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>bootstrap</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.airlift</groupId>
-            <artifactId>http-client</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.jetty.version>9.4.14.v20181114</dep.jetty.version>
         <dep.jersey.version>2.26</dep.jersey.version>
+        <dep.drift.version>1.25</dep.drift.version>
     </properties>
 
     <organization>
@@ -171,6 +172,74 @@
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>json</artifactId>
                 <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-protocol</artifactId>
+                <version>${dep.drift.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>aopalliance-repackaged</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-codec</artifactId>
+                <version>${dep.drift.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>aopalliance-repackaged</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-api</artifactId>
+                <version>${dep.drift.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>aopalliance-repackaged</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-transport-netty</artifactId>
+                <version>${dep.drift.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>aopalliance-repackaged</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.airlift</groupId>
+                        <artifactId>units</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
`application/x-thrift` media type is introduced to support Thrift encoding/decoding over HTTP.