### PR TITLE
Skip over unsupported algorithm

### DIFF
--- a/security/pom.xml
+++ b/security/pom.xml
@@ -28,6 +28,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- these are only used to validate the CSR is properly encoded -->
         <dependency>
             <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This test is going through java.Security's algorithms. It eventually
had something that bouncycastle didn't support—SHA512/256WITHRSA.