### PR TITLE
Add Authorization Support for External Jersey Resources

### DIFF
--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/AuthorizationFilter.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/AuthorizationFilter.java
@@ -31,10 +31,12 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import java.security.Principal;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.airlift.http.server.HttpServerConfig.AuthorizationPolicy;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -45,28 +47,35 @@ public class AuthorizationFilter
     private final Authorizer authorizer;
     private final AuthorizationPolicy authorizationPolicy;
     private final Set<String> defaultAllowedRoles;
+    private final Map<Class<?>, Map<String, String>> roleMaps;
 
     @Context
     private ResourceInfo resourceInfo;
 
     @Inject
-    public AuthorizationFilter(Authorizer authorizer, HttpServerConfig httpServerConfig)
+    public AuthorizationFilter(
+            Authorizer authorizer,
+            HttpServerConfig httpServerConfig,
+            @RoleMapping Map<Class<?>, Map<String, String>> roleMaps)
     {
         this(
                 authorizer,
                 httpServerConfig.getDefaultAuthorizationPolicy(),
-                httpServerConfig.getDefaultAllowedRoles());
+                httpServerConfig.getDefaultAllowedRoles(),
+                roleMaps);
     }
 
     @VisibleForTesting
     public AuthorizationFilter(
             Authorizer authorizer,
             AuthorizationPolicy authorizationPolicy,
-            Set<String> defaultAllowedRoles)
+            Set<String> defaultAllowedRoles,
+            Map<Class<?>, Map<String, String>> roleMaps)
     {
         this.authorizer = requireNonNull(authorizer, "authorizer is null");
         this.authorizationPolicy = requireNonNull(authorizationPolicy, "authorizationPolicy is null");
         this.defaultAllowedRoles = requireNonNull(defaultAllowedRoles, "defaultAllowedRoles is null");
+        this.roleMaps = requireNonNull(roleMaps, "roleMaps is null");
     }
 
     @Override
@@ -96,6 +105,12 @@ public class AuthorizationFilter
                     break;
                 default:
             }
+        }
+        else if (roleMaps.containsKey(resourceInfo.getResourceClass())) {
+            allowedRoles = Optional.of(allowedRoles.get()
+                    .stream()
+                    .map(role -> roleMaps.get(resourceInfo.getResourceClass()).getOrDefault(role, role))
+                    .collect(toImmutableSet()));
         }
 
         AuthorizationResult result = authorizer.authorize(principal, allowedRoles.get());

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/JaxrsBinder.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/JaxrsBinder.java
@@ -1,11 +1,16 @@
 package com.facebook.airlift.jaxrs;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 
+import java.util.Map;
+
 import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.util.Objects.requireNonNull;
 
@@ -13,11 +18,17 @@ public class JaxrsBinder
 {
     private final Multibinder<Object> resourceBinder;
     private final Binder binder;
+    private final MapBinder<Class<?>, Map<String, String>> resourceRolesMappingBinder;
 
     private JaxrsBinder(Binder binder)
     {
         this.binder = requireNonNull(binder, "binder is null").skipSources(getClass());
         this.resourceBinder = newSetBinder(binder, Object.class, JaxrsResource.class).permitDuplicates();
+        this.resourceRolesMappingBinder = newMapBinder(
+                binder,
+                new TypeLiteral<Class<?>>() {},
+                new TypeLiteral<Map<String, String>>() {},
+                RoleMapping.class);
     }
 
     public static JaxrsBinder jaxrsBinder(Binder binder)
@@ -25,10 +36,11 @@ public class JaxrsBinder
         return new JaxrsBinder(binder);
     }
 
-    public void bind(Class<?> implementation)
+    public ResourceBinding bind(Class<?> implementation)
     {
         binder.bind(implementation).in(SINGLETON);
         resourceBinder.addBinding().to(implementation).in(SINGLETON);
+        return new ResourceBinding(implementation, resourceRolesMappingBinder);
     }
 
     public void bind(TypeLiteral<?> implementation)
@@ -43,8 +55,29 @@ public class JaxrsBinder
         resourceBinder.addBinding().to(targetKey).in(SINGLETON);
     }
 
-    public void bindInstance(Object instance)
+    public ResourceBinding bindInstance(Object instance)
     {
         resourceBinder.addBinding().toInstance(instance);
+        return new ResourceBinding(instance.getClass(), resourceRolesMappingBinder);
+    }
+
+    public static class ResourceBinding
+    {
+        private final Class<?> implementation;
+        private final MapBinder<Class<?>, Map<String, String>> resourceRolesMappingBinder;
+
+        public ResourceBinding(
+                Class<?> implementation,
+                MapBinder<Class<?>, Map<String, String>> resourceRolesMappingBinder)
+        {
+            this.implementation = implementation;
+            this.resourceRolesMappingBinder = resourceRolesMappingBinder;
+        }
+
+        public ResourceBinding withRolesMapping(Map<String, String> rolesMapping)
+        {
+            resourceRolesMappingBinder.addBinding(implementation).toInstance(ImmutableMap.copyOf(rolesMapping));
+            return this;
+        }
     }
 }

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/RoleMapping.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/RoleMapping.java
@@ -1,0 +1,16 @@
+package com.facebook.airlift.jaxrs;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(PARAMETER)
+@Qualifier
+public @interface RoleMapping
+{
+}


### PR DESCRIPTION
Partially implements: prestodb/presto [#14639](https://github.com/prestodb/presto/issues/14639)

## Motivation
We want to add authorization support with Hipster for external Jersey resources.

The idea here is providing a new method in `JaxrsBinder` - When user binds Jersey resource, they can pass a `roleMap` with it. We store the maps in authorization filter and convert roles bases on these maps when necessary.

#### Method Signature
```java
void bindWithRolesMapping(Class<?> implementation, Map<String, String> roleMap)
```

#### Why pass a map manually instead of providing a config?
1. If we make it configurable, the config would be complicated. In order to indicate which map belongs to which resource It would be something like `Map<String, Map<String, String>>` and make it hard to configure.
2. We may want it to be flexible to let users decide how to generate the map by themselves. In this way:
   1. They can create it manually:
   ```java
   jaxrsBinder(binder).bindWithRolesMapping(ServiceResource.class,
                   ImmutableMap.of("fetcher", "internal"));
   ```
   2. They can use their own config class:
   ```java
   jaxrsBinder(binder).bindWithRolesMapping(ServiceResource.class,
                   buildConfigObject(DiscoveryConfig.class).getRoleMap());
   ```
   3. Even inject it somewhere else