### PR TITLE
Fix memory size calculation

### DIFF
--- a/stats/src/main/java/com/facebook/airlift/stats/QuantileDigest.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/QuantileDigest.java
@@ -541,9 +541,9 @@ public class QuantileDigest
         return Math.min(max, chosen.get());
     }
 
-    public int estimatedInMemorySizeInBytes()
+    public long estimatedInMemorySizeInBytes()
     {
-        return (int) (QUANTILE_DIGEST_SIZE +
+        return (QUANTILE_DIGEST_SIZE +
                 SizeOf.sizeOf(counts) +
                 SizeOf.sizeOf(levels) +
                 SizeOf.sizeOf(values) +


### PR DESCRIPTION
We are down casting long to int which is causing an issue while adding memorySize
https://github.com/prestodb/presto/blob/master/presto-memory-context/src/main/java/com/facebook/presto/memory/context/SimpleLocalMemoryContext.java#L59

PR's depending on this
https://github.com/prestodb/presto/pull/14975
https://github.com/facebookexternal/presto-facebook/pull/1113