### PR TITLE
Simplify thrift mime types

### DIFF
--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftRequestUtils.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftRequestUtils.java
@@ -16,7 +16,9 @@ package com.facebook.airlift.http.client.thrift;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.drift.codec.ThriftCodec;
 import com.facebook.drift.transport.netty.codec.Protocol;
-import com.google.common.net.MediaType;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
 import static com.facebook.airlift.http.client.Request.Builder.preparePost;
@@ -25,10 +27,10 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 
 public class ThriftRequestUtils
 {
-    private static final MediaType THRIFT_TYPE = MediaType.create("application", "x-thrift");
-    private static final String TYPE_BINARY = THRIFT_TYPE.withParameter("t", Protocol.BINARY.name()).toString().toLowerCase();
-    private static final String TYPE_COMPACT = THRIFT_TYPE.withParameter("t", Protocol.COMPACT.name()).toString().toLowerCase();
-    private static final String TYPE_FBCOMPACT = THRIFT_TYPE.withParameter("t", Protocol.FB_COMPACT.name()).toString().toLowerCase();
+    public static final String TYPE_BINARY = "application/x-thrift+binary";
+    public static final String TYPE_COMPACT = "application/x-thrift+compact";
+    public static final String TYPE_FBCOMPACT = "application/x-thrift+fb_compact";
+    public static final List<String> validThriftMimeTypes = ImmutableList.of(TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT);
 
     private ThriftRequestUtils() {}
 
@@ -50,8 +52,7 @@ public class ThriftRequestUtils
     {
         String type = getType(protocol);
         return prepareGet()
-                .setHeader(ACCEPT, type)
-                .setHeader(CONTENT_TYPE, type);
+                .setHeader(ACCEPT, type);
     }
 
     private static <T> ThriftBodyGenerator<T> createThriftBodyGenerator(T instance, ThriftCodec<T> thriftCodec, Protocol protocol)

--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftResponse.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftResponse.java
@@ -14,6 +14,7 @@ public class ThriftResponse<T>
 {
     private final int statusCode;
     private final String statusMessage;
+    private final String errorMessage;
     private final ListMultimap<HeaderName, String> headers;
     private final T value;
     private final IllegalArgumentException exception;
@@ -21,12 +22,14 @@ public class ThriftResponse<T>
     ThriftResponse(
             int statusCode,
             String statusMessage,
+            String errorMessage,
             ListMultimap<HeaderName, String> headers,
             T value,
             IllegalArgumentException exception)
     {
         this.statusCode = statusCode;
         this.statusMessage = requireNonNull(statusMessage, "statusMessage is null");
+        this.errorMessage = errorMessage;
         this.headers = headers != null ? ImmutableListMultimap.copyOf(headers) : null;
         this.value = value;
         this.exception = exception;
@@ -40,6 +43,11 @@ public class ThriftResponse<T>
     public String getStatusMessage()
     {
         return statusMessage;
+    }
+
+    public String getErrorMessage()
+    {
+        return errorMessage;
     }
 
     public T getValue()

--- a/jaxrs-testing/pom.xml
+++ b/jaxrs-testing/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>drift-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-protocol</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapper.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapper.java
@@ -75,7 +75,7 @@ public class ThriftMapper
         }
         catch (Exception e) {
             // we want to return a 400 for bad Thrift but not for a real IO exception
-            if (e instanceof IOException && !(e instanceof EOFException)) {
+            if (e instanceof IOException && !(e instanceof ThriftProtocolException) && !(e instanceof EOFException)) {
                 throw (IOException) e;
             }
             //The IOException is likely to be wrapped into a TTransportException

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapper.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapper.java
@@ -35,13 +35,16 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.Map;
 
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_BINARY;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_COMPACT;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_FBCOMPACT;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.validThriftMimeTypes;
 import static java.util.Objects.requireNonNull;
 
 @Provider
-@Consumes("application/x-thrift")
-@Produces("application/x-thrift")
+@Consumes({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
+@Produces({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
 public class ThriftMapper
         extends BaseMapper
 {
@@ -117,14 +120,13 @@ public class ThriftMapper
 
     private Protocol getThriftProtocol(MediaType mediaType, ThriftCodec<?> thriftCodec)
     {
-        Map<String, String> parameters = mediaType.getParameters();
+        String mimeType = mediaType.toString();
 
-        if (!parameters.containsKey("t")) {
+        if (!validThriftMimeTypes.contains(mimeType)) {
             throw new IllegalArgumentException("Invalid response. No protocol type specified. Unable to create " + thriftCodec.getType() + " from THRIFT response");
         }
-        if (parameters.size() != 1) {
-            throw new IllegalArgumentException("Invalid response. Invalid parameter count:" + parameters.size() + " expected 1. Unable to create " + thriftCodec.getType() + " from THRIFT response");
-        }
-        return Protocol.valueOf(parameters.get("t").toUpperCase());
+
+        String encodingType = mimeType.substring("application/x-thrift+".length());
+        return Protocol.valueOf(encodingType.toUpperCase());
     }
 }

--- a/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestThriftMapper.java
+++ b/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestThriftMapper.java
@@ -31,7 +31,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.zip.ZipException;
 
 import static org.testng.Assert.assertEquals;
@@ -56,9 +55,7 @@ public class TestThriftMapper
         ThriftMapper thriftMapper = new ThriftMapper(codecManager);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         MultivaluedMap<String, Object> headers = new GuavaMultivaluedMap<>();
-        HashMap<String, String> parameters = new HashMap<>();
-        parameters.put("t", "binary");
-        MediaType mediaType = new MediaType("application", "x-thrift", parameters);
+        MediaType mediaType = new MediaType("application", "x-thrift+binary");
         thriftMapper.writeTo(testThriftMessage, TestThriftMessage.class, null, null, mediaType, headers, outputStream);
         TestThriftMessage readFrom = (TestThriftMessage) thriftMapper.readFrom(Object.class, TestThriftMessage.class, null, mediaType, null, new ByteArrayInputStream(outputStream.toByteArray()));
         assertEquals(readFrom.getTestString(), testThriftMessage.getTestString());


### PR DESCRIPTION
Simplify thrift mime types to avoid the usage of parameters.
This is inspired from how grpc uses mime types.
e.g. The old mime type application/x-thrift; t=binary will be replaced
with application/x-thrift+binary.