### PR TITLE
Add qs parameter for thrift media types

### DIFF
--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftRequestUtils.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftRequestUtils.java
@@ -27,10 +27,10 @@ import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 
 public class ThriftRequestUtils
 {
-    public static final String TYPE_BINARY = "application/x-thrift+binary";
-    public static final String TYPE_COMPACT = "application/x-thrift+compact";
-    public static final String TYPE_FBCOMPACT = "application/x-thrift+fb_compact";
-    public static final List<String> validThriftMimeTypes = ImmutableList.of(TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT);
+    public static final String APPLICATION_THRIFT_BINARY = "application/x-thrift+binary";
+    public static final String APPLICATION_THRIFT_COMPACT = "application/x-thrift+compact";
+    public static final String APPLICATION_THRIFT_FB_COMPACT = "application/x-thrift+fb_compact";
+    public static final List<String> validThriftMimeTypes = ImmutableList.of(APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT);
 
     private ThriftRequestUtils() {}
 
@@ -64,11 +64,11 @@ public class ThriftRequestUtils
     {
         switch (protocol) {
             case BINARY:
-                return TYPE_BINARY;
+                return APPLICATION_THRIFT_BINARY;
             case COMPACT:
-                return TYPE_COMPACT;
+                return APPLICATION_THRIFT_COMPACT;
             case FB_COMPACT:
-                return TYPE_FBCOMPACT;
+                return APPLICATION_THRIFT_FB_COMPACT;
             default:
                 throw new IllegalArgumentException("Invalid thrift protocol");
         }

--- a/jaxrs-testing/src/test/java/com/facebook/airlift/jaxrs/testing/TestJaxrsThriftTestingHttpProcessor.java
+++ b/jaxrs-testing/src/test/java/com/facebook/airlift/jaxrs/testing/TestJaxrsThriftTestingHttpProcessor.java
@@ -42,9 +42,9 @@ import java.net.URI;
 
 import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
 import static com.facebook.airlift.http.client.Request.Builder.preparePost;
-import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_BINARY;
-import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_COMPACT;
-import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_FBCOMPACT;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_BINARY;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_COMPACT;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_FB_COMPACT;
 import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.prepareThriftGet;
 import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.prepareThriftPost;
 import static com.facebook.drift.protocol.TType.STOP;
@@ -197,8 +197,8 @@ public class TestJaxrsThriftTestingHttpProcessor
     public void testInvalidRequestBody()
     {
         Request request = preparePost()
-                .setHeader(ACCEPT, ThriftRequestUtils.TYPE_COMPACT)
-                .setHeader(HttpHeaders.CONTENT_TYPE, ThriftRequestUtils.TYPE_COMPACT)
+                .setHeader(ACCEPT, ThriftRequestUtils.APPLICATION_THRIFT_COMPACT)
+                .setHeader(HttpHeaders.CONTENT_TYPE, ThriftRequestUtils.APPLICATION_THRIFT_COMPACT)
                 //Setting an invalid request body
                 .setBodyGenerator(out -> out.write(new byte[] {'C', 'A', 'F', 'E', 'B', 'A', 'B', 'E', STOP}))
                 .setUri(URI.create("http://fake.invalid/http-thrift/post/2"))
@@ -246,7 +246,7 @@ public class TestJaxrsThriftTestingHttpProcessor
     {
         @Path("get/{id}")
         @GET
-        @Produces({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
+        @Produces({APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
         public TestThriftMessage getTestMessage(@PathParam("id") long id)
         {
             return new TestThriftMessage("abc", id);
@@ -254,8 +254,8 @@ public class TestJaxrsThriftTestingHttpProcessor
 
         @Path("post/{id}")
         @POST
-        @Consumes({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
-        @Produces({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
+        @Consumes({APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
+        @Produces({APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
         public TestThriftMessage postTestMessage(@PathParam("id") long id, TestThriftMessage testThriftMessage)
         {
             return new TestThriftMessage(testThriftMessage.getTestString(), id + testThriftMessage.getTestLong());
@@ -263,8 +263,8 @@ public class TestJaxrsThriftTestingHttpProcessor
 
         @Path("fail/{message}")
         @GET
-        @Consumes({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
-        @Produces({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
+        @Consumes({APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
+        @Produces({APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
         public TestThriftMessage fail(@PathParam("message") String errorMessage)
         {
             throw new TestingException(errorMessage);

--- a/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapper.java
+++ b/jaxrs/src/main/java/com/facebook/airlift/jaxrs/thrift/ThriftMapper.java
@@ -36,20 +36,25 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_BINARY;
-import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_COMPACT;
-import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.TYPE_FBCOMPACT;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_BINARY;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_COMPACT;
+import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.APPLICATION_THRIFT_FB_COMPACT;
 import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.validThriftMimeTypes;
+import static com.facebook.airlift.jaxrs.thrift.ThriftMapper.APPLICATION_THRIFT_BINARY_QS;
+import static com.facebook.airlift.jaxrs.thrift.ThriftMapper.APPLICATION_THRIFT_COMPACT_QS;
+import static com.facebook.airlift.jaxrs.thrift.ThriftMapper.APPLICATION_THRIFT_FB_COMPACT_QS;
 import static java.util.Objects.requireNonNull;
 
 @Provider
-@Consumes({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
-@Produces({TYPE_BINARY, TYPE_COMPACT, TYPE_FBCOMPACT})
+@Consumes({APPLICATION_THRIFT_BINARY, APPLICATION_THRIFT_COMPACT, APPLICATION_THRIFT_FB_COMPACT})
+@Produces({APPLICATION_THRIFT_BINARY_QS, APPLICATION_THRIFT_COMPACT_QS, APPLICATION_THRIFT_FB_COMPACT_QS})
 public class ThriftMapper
         extends BaseMapper
 {
     public static final Logger log = Logger.get(ThriftMapper.class);
-
+    static final String APPLICATION_THRIFT_BINARY_QS = "application/x-thrift+binary; qs=0.1";
+    static final String APPLICATION_THRIFT_COMPACT_QS = "application/x-thrift+compact; qs=0.1";
+    static final String APPLICATION_THRIFT_FB_COMPACT_QS = "application/x-thrift+fb_compact; qs=0.1";
     private final ThriftCodecManager thriftCodecManager;
 
     @Inject


### PR DESCRIPTION
To support ordering of media types during content negotiation
adding in qs parameter for thrift media types.