### PR TITLE
Supply default values for Bootstrap options via System properties

### DIFF
--- a/bootstrap/src/main/java/com/facebook/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/com/facebook/airlift/bootstrap/Bootstrap.java
@@ -49,6 +49,7 @@ import java.util.TreeMap;
 
 import static com.facebook.airlift.configuration.ConfigurationLoader.getSystemProperties;
 import static com.facebook.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static java.lang.Boolean.parseBoolean;
 
 /**
  * Entry point for an application built using the platform codebase.
@@ -69,9 +70,9 @@ public class Bootstrap
     private Map<String, String> requiredConfigurationProperties;
     private Map<String, String> optionalConfigurationProperties;
     private boolean initializeLogging = true;
-    private boolean quiet;
-    private boolean strictConfig;
-    private boolean requireExplicitBindings = true;
+    private boolean quiet = getDefaultFromProperties("bootstrap.quiet", false);
+    private boolean strictConfig = getDefaultFromProperties("bootstrap.strict-config", true);
+    private boolean requireExplicitBindings = getDefaultFromProperties("bootstrap.require-explicit-bindings", true);
 
     private boolean initialized;
 
@@ -138,9 +139,14 @@ public class Bootstrap
         return this;
     }
 
-    public Bootstrap strictConfig()
+    /**
+     * Disable the requirement that required configuration property must be used
+     * in some Config classes. This could be useful for testing purpose when
+     * deploying an old Presto version with the latest set of config properties.
+     */
+    public Bootstrap noStrictConfig()
     {
-        this.strictConfig = true;
+        this.strictConfig = false;
         return this;
     }
 
@@ -290,5 +296,14 @@ public class Bootstrap
             }
         }
         return columnPrinter;
+    }
+
+    private boolean getDefaultFromProperties(String propertyName, boolean defaultValue)
+    {
+        String propertyValue = System.getProperty(propertyName);
+        if (propertyValue != null) {
+            return parseBoolean(propertyValue);
+        }
+        return defaultValue;
     }
 }

--- a/bootstrap/src/test/java/com/facebook/airlift/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/com/facebook/airlift/bootstrap/TestBootstrap.java
@@ -15,15 +15,22 @@
  */
 package com.facebook.airlift.bootstrap;
 
+import com.facebook.airlift.configuration.Config;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
+import com.google.inject.CreationException;
+import com.google.inject.Module;
 import com.google.inject.ProvisionException;
 import org.testng.annotations.Test;
 
 import javax.inject.Inject;
 
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.testing.Assertions.assertContains;
 import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true)
 public class TestBootstrap
 {
     @Test
@@ -58,6 +65,34 @@ public class TestBootstrap
         }
     }
 
+    @Test(expectedExceptions = CreationException.class, expectedExceptionsMessageRegExp = ".*Configuration property 'not-supported' was not used.*")
+    public void testStrictConfigDefault()
+    {
+        new Bootstrap(new ConfigModule())
+                .setRequiredConfigurationProperties(ImmutableMap.of("not-supported", "1"))
+                .initialize();
+    }
+
+    @Test(expectedExceptions = CreationException.class, expectedExceptionsMessageRegExp = ".*Configuration property 'not-supported' was not used.*")
+    public void testStrictConfig()
+    {
+        System.setProperty("bootstrap.strict-config", "true");
+        new Bootstrap(new ConfigModule())
+                .setRequiredConfigurationProperties(ImmutableMap.of("not-supported", "1"))
+                .initialize();
+    }
+
+    @Test
+    public void testNoStrictConfig()
+    {
+        System.setProperty("bootstrap.strict-config", "false");
+        new Bootstrap(new ConfigModule())
+                .setRequiredConfigurationProperties(ImmutableMap.of("not-supported", "1"))
+                .initialize()
+                .getInstance(LifeCycleManager.class)
+                .stop();
+    }
+
     public static class Instance {}
 
     public static class InstanceA
@@ -70,5 +105,32 @@ public class TestBootstrap
     {
         @Inject
         public InstanceB(InstanceA a) {}
+    }
+
+    public static class TestingConfig
+    {
+        private String value;
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        @Config("value")
+        public TestingConfig setValue(String value)
+        {
+            this.value = value;
+            return this;
+        }
+    }
+
+    private static class ConfigModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            configBinder(binder).bindConfig(TestingConfig.class);
+        }
     }
 }

--- a/discovery/src/test/java/com/facebook/airlift/discovery/client/TestDiscoveryModule.java
+++ b/discovery/src/test/java/com/facebook/airlift/discovery/client/TestDiscoveryModule.java
@@ -32,7 +32,6 @@ public class TestDiscoveryModule
                 new DiscoveryModule());
 
         Injector injector = app
-                .strictConfig()
                 .doNotInitializeLogging()
                 .initialize();
 

--- a/http-client/src/test/java/com/facebook/airlift/http/client/TestHttpClientBinder.java
+++ b/http-client/src/test/java/com/facebook/airlift/http/client/TestHttpClientBinder.java
@@ -54,7 +54,6 @@ public class TestHttpClientBinder
                         .withConfigDefaults(config -> config.setRequestTimeout(new Duration(33, MINUTES))),
                 new TraceTokenModule())
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         JettyHttpClient httpClient = (JettyHttpClient) injector.getInstance(Key.get(HttpClient.class, FooClient.class));
@@ -82,7 +81,6 @@ public class TestHttpClientBinder
                 },
                 new TraceTokenModule())
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         JettyHttpClient fooClient = (JettyHttpClient) injector.getInstance(Key.get(HttpClient.class, FooClient.class));
@@ -115,7 +113,6 @@ public class TestHttpClientBinder
                 },
                 new TraceTokenModule())
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         assertFilterCount(injector.getInstance(Key.get(HttpClient.class, FooClient.class)), 3);
@@ -133,7 +130,6 @@ public class TestHttpClientBinder
                         .withTracing(),
                 new TraceTokenModule())
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         HttpClient httpClient = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
@@ -147,7 +143,6 @@ public class TestHttpClientBinder
         Injector injector = new Bootstrap(
                 binder -> httpClientBinder(binder).bindHttpClient("foo", FooClient.class))
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         assertNotNull(injector.getInstance(Key.get(HttpClient.class, FooClient.class)));
@@ -162,7 +157,6 @@ public class TestHttpClientBinder
                         .withAlias(FooAlias1.class)
                         .withAliases(ImmutableList.of(FooAlias2.class, FooAlias3.class)))
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         HttpClient client = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
@@ -180,7 +174,6 @@ public class TestHttpClientBinder
                         .withAlias(FooAlias1.class)
                         .withAlias(FooAlias2.class))
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         HttpClient client = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
@@ -198,7 +191,6 @@ public class TestHttpClientBinder
                     httpClientBinder(binder).bindHttpClient("bar", BarClient.class);
                 })
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         HttpClient fooClient = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
@@ -216,7 +208,6 @@ public class TestHttpClientBinder
                     httpClientBinder(binder).bindHttpClient("bar", BarClient.class);
                 })
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         HttpClient fooClient = injector.getInstance(Key.get(HttpClient.class, FooClient.class));

--- a/http-server/src/test/java/com/facebook/airlift/http/server/TestAuthorizationEnabledServletInHttpServer.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/TestAuthorizationEnabledServletInHttpServer.java
@@ -328,7 +328,6 @@ public class TestAuthorizationEnabledServletInHttpServer
                 .build();
 
         return new Bootstrap(modules)
-                .strictConfig()
                 .doNotInitializeLogging()
                 .setOptionalConfigurationProperties(serverProperties)
                 .quiet()

--- a/http-server/src/test/java/com/facebook/airlift/http/server/testing/TestTestingHttpServer.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/testing/TestTestingHttpServer.java
@@ -157,7 +157,6 @@ public class TestTestingHttpServer
                 });
 
         Injector injector = app
-                .strictConfig()
                 .doNotInitializeLogging()
                 .initialize();
 
@@ -192,7 +191,6 @@ public class TestTestingHttpServer
                 });
 
         Injector injector = app
-                .strictConfig()
                 .doNotInitializeLogging()
                 .initialize();
 
@@ -231,7 +229,6 @@ public class TestTestingHttpServer
                 });
 
         Injector injector = app
-                .strictConfig()
                 .doNotInitializeLogging()
                 .initialize();
 

--- a/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestAuthorizationFilterInHttpServer.java
+++ b/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestAuthorizationFilterInHttpServer.java
@@ -398,7 +398,6 @@ public class TestAuthorizationFilterInHttpServer
                 .build();
 
         return new Bootstrap(modules)
-                .strictConfig()
                 .doNotInitializeLogging()
                 .setOptionalConfigurationProperties(serverProperties)
                 .quiet()

--- a/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestOverrideMethodFilterInHttpServer.java
+++ b/jaxrs/src/test/java/com/facebook/airlift/jaxrs/TestOverrideMethodFilterInHttpServer.java
@@ -296,7 +296,6 @@ public class TestOverrideMethodFilterInHttpServer
                     .build();
 
             return new Bootstrap(modules)
-                    .strictConfig()
                     .doNotInitializeLogging()
                     .quiet()
                     .initialize()

--- a/jmx-http-rpc/src/test/java/com/facebook/airlift/jmx/http/rpc/TestMBeanServerResource.java
+++ b/jmx-http-rpc/src/test/java/com/facebook/airlift/jmx/http/rpc/TestMBeanServerResource.java
@@ -75,7 +75,6 @@ public class TestMBeanServerResource
                 });
 
         Injector injector = app
-                .strictConfig()
                 .doNotInitializeLogging()
                 .initialize();
 

--- a/jmx-http/src/test/java/com/facebook/airlift/jmx/TestMBeanResource.java
+++ b/jmx-http/src/test/java/com/facebook/airlift/jmx/TestMBeanResource.java
@@ -66,7 +66,6 @@ public class TestMBeanResource
 
         Injector injector = app
                 .quiet()
-                .strictConfig()
                 .initialize();
 
         lifeCycleManager = injector.getInstance(LifeCycleManager.class);

--- a/sample-server/src/main/java/com/facebook/airlift/sample/Main.java
+++ b/sample-server/src/main/java/com/facebook/airlift/sample/Main.java
@@ -57,7 +57,7 @@ public final class Main
                 new MainModule());
 
         try {
-            Injector injector = app.strictConfig().initialize();
+            Injector injector = app.initialize();
             injector.getInstance(Announcer.class).start();
         }
         catch (Throwable e) {

--- a/sample-server/src/test/java/com/facebook/airlift/sample/TestServer.java
+++ b/sample-server/src/test/java/com/facebook/airlift/sample/TestServer.java
@@ -89,7 +89,6 @@ public class TestServer
                 new MainModule());
 
         Injector injector = app
-                .strictConfig()
                 .doNotInitializeLogging()
                 .initialize();
 

--- a/skeleton-server/src/main/java/com/facebook/airlift/skeleton/Main.java
+++ b/skeleton-server/src/main/java/com/facebook/airlift/skeleton/Main.java
@@ -57,7 +57,7 @@ public final class Main
                 new MainModule());
 
         try {
-            Injector injector = app.strictConfig().initialize();
+            Injector injector = app.initialize();
             injector.getInstance(Announcer.class).start();
         }
         catch (Throwable e) {

--- a/skeleton-server/src/test/java/com/facebook/airlift/skeleton/TestServer.java
+++ b/skeleton-server/src/test/java/com/facebook/airlift/skeleton/TestServer.java
@@ -46,7 +46,6 @@ public class TestServer
                 new MainModule());
 
         Injector injector = app
-                .strictConfig()
                 .doNotInitializeLogging()
                 .initialize();
 


### PR DESCRIPTION
- This allows specify default values for several options in Bootstrap for all Bootstrap object within a binary.
- Update the default value of strictConfig to `true`.

This enables us to disable strict config for all system and connector properties within Presto.