### PR TITLE
Create a generic thrift error response for http response with error code

### DIFF
--- a/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftResponseHandler.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/thrift/ThriftResponseHandler.java
@@ -32,7 +32,7 @@ import java.nio.charset.StandardCharsets;
 import static com.facebook.airlift.http.client.thrift.ThriftRequestUtils.validThriftMimeTypes;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static java.util.Objects.requireNonNull;
-import static org.eclipse.jetty.http.HttpStatus.isClientError;
+import static org.eclipse.jetty.http.HttpStatus.isSuccess;
 
 public class ThriftResponseHandler<T>
         implements ResponseHandler<ThriftResponse<T>, RuntimeException>
@@ -53,7 +53,7 @@ public class ThriftResponseHandler<T>
     @Override
     public ThriftResponse<T> handle(Request request, Response response)
     {
-        if (isClientError(response.getStatusCode())) {
+        if (!isSuccess(response.getStatusCode())) {
             return createErrorResponse(response);
         }
 


### PR DESCRIPTION
Currently ThriftResponseHandler is leveraging thift codec for all responses except with http status = 4xx (user error). So for cases where there are server errors(500) or timeout issues(503) etc, the response handler is broken as the codec does not understand the entity embedded into the http response. The change as part of this commit is to address this issue.

Test plan:
1. Unit test
2. Update airlift.version of presto locally, inject a test error in the code path and  use TestThriftSupport to verify response.
