### PR TITLE
Add PrivateLpcaSketch for private cardinality estimation

### DIFF
--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/BucketListener.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/BucketListener.java
@@ -13,23 +13,7 @@
  */
 package com.facebook.airlift.stats.cardinality;
 
-enum Format
+public interface BucketListener
 {
-    SPARSE_V1(0),
-    DENSE_V1(1),
-    SPARSE_V2(2),
-    DENSE_V2(3),
-    PRIVATE_LPCA_V1(4);
-
-    private byte tag;
-
-    Format(int tag)
-    {
-        this.tag = (byte) tag;
-    }
-
-    public byte getTag()
-    {
-        return tag;
-    }
+    void visit(int bucket, int value);
 }

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/DenseHll.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/DenseHll.java
@@ -343,6 +343,13 @@ final class DenseHll
         return this;
     }
 
+    public void eachBucket(BucketListener listener)
+    {
+        for (int i = 0; i < numberOfBuckets(indexBitLength); i++) {
+            listener.visit(i, getValue(i));
+        }
+    }
+
     public int estimatedSerializedSize()
     {
         return SizeOf.SIZE_OF_BYTE + // type + version

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/HllInstance.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/HllInstance.java
@@ -22,6 +22,8 @@ interface HllInstance
 
     long cardinality();
 
+    void eachBucket(BucketListener listener);
+
     int getIndexBitLength();
 
     int estimatedInMemorySize();

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/HyperLogLog.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/HyperLogLog.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
 import static com.facebook.airlift.stats.cardinality.Utils.indexBitLength;
+import static com.facebook.airlift.stats.cardinality.Utils.numberOfBuckets;
 import static com.google.common.base.Preconditions.checkArgument;
 
 public class HyperLogLog
@@ -97,6 +98,11 @@ public class HyperLogLog
         return instance.cardinality();
     }
 
+    public void eachBucket(BucketListener listener)
+    {
+        instance.eachBucket(listener);
+    }
+
     public int estimatedInMemorySize()
     {
         return instance.estimatedInMemorySize() + INSTANCE_SIZE;
@@ -105,6 +111,11 @@ public class HyperLogLog
     public int estimatedSerializedSize()
     {
         return instance.estimatedSerializedSize();
+    }
+
+    public int getNumberOfBuckets()
+    {
+        return numberOfBuckets(instance.getIndexBitLength());
     }
 
     public Slice serialize()

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/PrivateLpcaSketch.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/PrivateLpcaSketch.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.stats.cardinality;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SizeOf;
+import io.airlift.slice.Slice;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * A privacy-preserving cardinality sketch similar in spirit to HyperLogLog.
+ * This is essentially a data sketch that has buckets similar to those of HLL,
+ * but converted to binary values (above/below) relative to some threshold.
+ * This serves as a sort of data minimization. Additional noise is added to the
+ * sketch by randomly perturbing the buckets via randomized response.
+ * The final cardinality estimate is similar to the classical linear probabilistic
+ * counting algorithm (LPCA).
+ */
+@NotThreadSafe
+public class PrivateLpcaSketch
+{
+    private byte[] bitmap;
+    private final int threshold;
+    private final int numberOfBuckets;
+    private final double epsilon;
+    private final RandomizedResponseStrategy randomizedResponseStrategy;
+    private static final int BYTE_MASK = 0b11111111;
+
+    public PrivateLpcaSketch(HyperLogLog hll, double epsilon)
+    {
+        this(hll, epsilon, new SecureRandomizedResponse());
+    }
+
+    public PrivateLpcaSketch(Slice serialized)
+    {
+        this(serialized, new SecureRandomizedResponse());
+    }
+
+    public PrivateLpcaSketch(HyperLogLog hll, double epsilon, RandomizedResponseStrategy randomizedResponseStrategy)
+    {
+        this.randomizedResponseStrategy = randomizedResponseStrategy;
+        this.epsilon = epsilon;
+
+        numberOfBuckets = hll.getNumberOfBuckets();
+        threshold = findThreshold(hll);
+        writeBitmap(hll);
+        applyRandomizedResponse();
+    }
+
+    public PrivateLpcaSketch(Slice serialized, RandomizedResponseStrategy randomizedResponseStrategy)
+    {
+        this.randomizedResponseStrategy = randomizedResponseStrategy;
+
+        // Format:
+        // format | numberOfBuckets | threshold | epsilon | bitmap
+        BasicSliceInput input = serialized.getInput();
+        byte format = input.readByte();
+        checkArgument(format == Format.PRIVATE_LPCA_V1.getTag(), "Wrong format tag");
+
+        numberOfBuckets = input.readInt();
+        threshold = input.readInt();
+        epsilon = input.readDouble();
+        bitmap = new byte[numberOfBuckets / Byte.SIZE];
+        for (int i = 0; i < bitmap.length; i++) {
+            bitmap[i] = input.readByte();
+        }
+    }
+
+    private void applyRandomizedResponse()
+    {
+        double p = getFlipProbability();
+        for (int i = 0; i < numberOfBuckets; i++) {
+            if (randomizedResponseStrategy.shouldFlip(p)) {
+                flipBit(i);
+            }
+        }
+    }
+
+    private void applyRandomizedResponse(int bucket)
+    {
+        double p = getFlipProbability();
+        if (randomizedResponseStrategy.shouldFlip(p)) {
+            flipBit(bucket);
+        }
+    }
+
+    @VisibleForTesting
+    static int bitmapBitShift(int bucket)
+    {
+        return bucket % Byte.SIZE;
+    }
+
+    @VisibleForTesting
+    static int bitmapByteIndex(int bucket)
+    {
+        // n.b.: bucket is 0-indexed
+        return Math.floorDiv(bucket, Byte.SIZE);
+    }
+
+    public long cardinality()
+    {
+        double proportion = getDebiasedBitProportion();
+        double estimate = -Math.pow(2.0, threshold) * Math.log1p(-proportion) * numberOfBuckets;
+        return Math.round(estimate);
+    }
+
+    public int estimatedSerializedSize()
+    {
+        return SizeOf.SIZE_OF_BYTE + // type + version
+                SizeOf.SIZE_OF_INT + // number of buckets
+                SizeOf.SIZE_OF_INT + // threshold
+                SizeOf.SIZE_OF_DOUBLE + // epsilon
+                (numberOfBuckets / Byte.SIZE * SizeOf.SIZE_OF_BYTE); // bitmap
+    }
+
+    private static int findThreshold(HyperLogLog hll)
+    {
+        // This function is subject to change.
+        int[] values = new int[hll.getNumberOfBuckets()];
+        hll.eachBucket((i, value) -> values[i] = value);
+        Arrays.sort(values);
+        return values[Math.floorDiv(values.length, 2)];
+    }
+
+    @VisibleForTesting
+    void flipBit(int bucket)
+    {
+        byte oneBit = (byte) (1 << bitmapBitShift(bucket));
+        bitmap[bitmapByteIndex(bucket)] ^= oneBit;
+    }
+
+    @VisibleForTesting
+    byte[] getBitmap()
+    {
+        return bitmap;
+    }
+
+    private double getDebiasedBitProportion()
+    {
+        // Each bit has expectation:
+        // p + (1-2p) T_i,
+        // where T_i is the true bit value, and p is the (effective) flip probability.
+        // So the proportion of bits equal to 1 has expectation:
+        // p + (1-2p) T,
+        // where T is the true proportion.
+        double effProbability = randomizedResponseStrategy.effectiveProbability(getFlipProbability());
+        return (getRawBitProportion() - effProbability) / (1 - 2 * effProbability);
+    }
+
+    private double getFlipProbability()
+    {
+        return 1.0 / (Math.exp(epsilon) + 1.0);
+    }
+
+    public int getNumberOfBuckets()
+    {
+        return numberOfBuckets;
+    }
+
+    @VisibleForTesting
+    double getRawBitProportion()
+    {
+        double count = 0;
+        for (byte b : bitmap) {
+            count += Integer.bitCount(b & BYTE_MASK);
+        }
+        return count / numberOfBuckets;
+    }
+
+    public int getThreshold()
+    {
+        return threshold;
+    }
+
+    public Slice serialize()
+    {
+        int size = estimatedSerializedSize();
+
+        DynamicSliceOutput output = new DynamicSliceOutput(size)
+                .appendByte(Format.PRIVATE_LPCA_V1.getTag())
+                .appendInt(numberOfBuckets)
+                .appendInt(threshold)
+                .appendDouble(epsilon)
+                .appendBytes(bitmap);
+
+        return output.slice();
+    }
+
+    @VisibleForTesting
+    void setBit(int bucket, boolean value)
+    {
+        byte oneBit = (byte) (1 << bitmapBitShift(bucket));
+        if (value) {
+            bitmap[bitmapByteIndex(bucket)] |= oneBit;
+        }
+        else {
+            bitmap[bitmapByteIndex(bucket)] &= ~oneBit;
+        }
+    }
+
+    /**
+     * Updates current sketch by adding data from a second HyperLogLog
+     *
+     * @param hllOther HyperLogLog of data to add to current sketch
+     */
+    public void update(HyperLogLog hllOther)
+    {
+        checkArgument(hllOther.getNumberOfBuckets() == numberOfBuckets,
+                "Cannot update sketch using HyperLogLog with different number of buckets: %s vs %s", numberOfBuckets, hllOther.getNumberOfBuckets());
+
+        hllOther.eachBucket((i, value) -> {
+            // if the new HLL's bucket value is at or below threshold, we don't need to do anything
+            // if above threshold, we need to set to 1 and then re-apply randomized response on the bit
+            if (value > threshold) {
+                setBit(i, true);
+                applyRandomizedResponse(i);
+            }
+        });
+    }
+
+    private void writeBitmap(HyperLogLog hll)
+    {
+        bitmap = new byte[numberOfBuckets / Byte.SIZE];
+        hll.eachBucket((i, value) -> setBit(i, value > threshold));
+    }
+}

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/RandomizedResponseStrategy.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/RandomizedResponseStrategy.java
@@ -13,23 +13,9 @@
  */
 package com.facebook.airlift.stats.cardinality;
 
-enum Format
+public interface RandomizedResponseStrategy
 {
-    SPARSE_V1(0),
-    DENSE_V1(1),
-    SPARSE_V2(2),
-    DENSE_V2(3),
-    PRIVATE_LPCA_V1(4);
+    double effectiveProbability(double flipProbability);
 
-    private byte tag;
-
-    Format(int tag)
-    {
-        this.tag = (byte) tag;
-    }
-
-    public byte getTag()
-    {
-        return tag;
-    }
+    boolean shouldFlip(double flipProbability);
 }

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/SecureRandomizedResponse.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/SecureRandomizedResponse.java
@@ -13,23 +13,25 @@
  */
 package com.facebook.airlift.stats.cardinality;
 
-enum Format
+import java.security.SecureRandom;
+
+public class SecureRandomizedResponse
+        implements RandomizedResponseStrategy
 {
-    SPARSE_V1(0),
-    DENSE_V1(1),
-    SPARSE_V2(2),
-    DENSE_V2(3),
-    PRIVATE_LPCA_V1(4);
+    private final SecureRandom random;
 
-    private byte tag;
-
-    Format(int tag)
+    public SecureRandomizedResponse()
     {
-        this.tag = (byte) tag;
+        this.random = new SecureRandom();
     }
 
-    public byte getTag()
+    public double effectiveProbability(double flipProbability)
     {
-        return tag;
+        return flipProbability;
+    }
+
+    public boolean shouldFlip(double flipProbability)
+    {
+        return random.nextDouble() <= flipProbability;
     }
 }

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/SparseHll.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/SparseHll.java
@@ -151,7 +151,12 @@ final class SparseHll
     public DenseHll toDense()
     {
         DenseHll result = new DenseHll(indexBitLength);
+        eachBucket(result::insert);
+        return result;
+    }
 
+    public void eachBucket(BucketListener listener)
+    {
         for (int i = 0; i < numberOfEntries; i++) {
             int entry = entries[i];
 
@@ -170,10 +175,8 @@ final class SparseHll
                 zeros = bits + decodeBucketValue(entry);
             }
 
-            result.insert(bucket, zeros + 1); // + 1 because HLL stores leading number of zeros + 1
+            listener.visit(bucket, zeros + 1);
         }
-
-        return result;
     }
 
     @Override

--- a/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestHyperLogLog.java
+++ b/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestHyperLogLog.java
@@ -128,6 +128,16 @@ public class TestHyperLogLog
     }
 
     @Test
+    public void testNumberOfBuckets()
+    {
+        int[] bucketCounts = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096};
+        for (int count : bucketCounts) {
+            HyperLogLog hll = HyperLogLog.newInstance(count);
+            assertEquals(hll.getNumberOfBuckets(), count);
+        }
+    }
+
+    @Test
     public void testRoundtrip()
             throws Exception
     {

--- a/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestPrivateLpcaSketch.java
+++ b/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestPrivateLpcaSketch.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.stats.cardinality;
+
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import static io.airlift.slice.testing.SliceAssertions.assertSlicesEqual;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestPrivateLpcaSketch
+{
+    @Test
+    public void testThresholding()
+    {
+        HyperLogLog hll = HyperLogLog.newInstance(1024);
+        for (int i = 0; i < 100_000; i++) {
+            hll.add(i);
+        }
+        PrivateLpcaSketch lpca = new PrivateLpcaSketch(hll, 1.0, new TestingRandomizedResponse());
+        int threshold = lpca.getThreshold();
+        int[] rawBuckets = getBucketValues(hll);
+        for (int i = 0; i < rawBuckets.length; i++) {
+            assertEquals(getBit(lpca, i), rawBuckets[i] > threshold);
+        }
+    }
+
+    @Test
+    public void testRoundTrip()
+    {
+        HyperLogLog hll = HyperLogLog.newInstance(1024);
+        for (int i = 0; i < 100_000; i++) {
+            hll.add(i);
+        }
+        PrivateLpcaSketch one = new PrivateLpcaSketch(hll, 1.0);
+        Slice serialized = one.serialize();
+        PrivateLpcaSketch two = new PrivateLpcaSketch(serialized);
+        Slice reserialized = two.serialize();
+        assertSlicesEqual(serialized, reserialized);
+    }
+
+    @Test
+    public void testBitmapSize()
+    {
+        // The bitmap should consist of 1 bit per bucket (1 byte per 8 buckets).
+        int[] bucketCounts = {16, 32, 64, 128, 256, 512, 1024, 2048, 4096};
+        for (int count : bucketCounts) {
+            HyperLogLog hll = HyperLogLog.newInstance(count);
+            PrivateLpcaSketch lpca = new PrivateLpcaSketch(hll, 1.0);
+            assertEquals(lpca.getBitmap().length * 8, count);
+        }
+    }
+
+    @Test
+    public void testUpdate()
+    {
+        HyperLogLog hll1 = HyperLogLog.newInstance(1024);
+        HyperLogLog hll2 = HyperLogLog.newInstance(1024);
+        for (int i = 0; i < 100_000; i++) {
+            hll1.add(i + 1);
+            hll2.add(-i);
+        }
+
+        PrivateLpcaSketch lpca = new PrivateLpcaSketch(hll1, 1.0, new TestingRandomizedResponse());
+        lpca.update(hll2);
+
+        int threshold = lpca.getThreshold();
+        int[] values1 = getBucketValues(hll1);
+        int[] values2 = getBucketValues(hll2);
+        for (int i = 0; i < values1.length; i++) {
+            assertEquals(getBit(lpca, i), Math.max(values1[i], values2[i]) > threshold);
+        }
+    }
+
+    @Test
+    public void testUpdateIncompatible()
+    {
+        HyperLogLog hll1 = HyperLogLog.newInstance(1024);
+        HyperLogLog hll2 = HyperLogLog.newInstance(512);
+        PrivateLpcaSketch lpca = new PrivateLpcaSketch(hll1, 1.0, new TestingRandomizedResponse());
+
+        boolean thrown = false;
+
+        try {
+            lpca.update(hll2); // should throw IllegalArgumentException
+        }
+        catch (IllegalArgumentException e) {
+            thrown = true;
+        }
+
+        assertTrue(thrown);
+    }
+
+    @Test
+    public void testSetBit()
+    {
+        HyperLogLog hll = HyperLogLog.newInstance(32);
+        PrivateLpcaSketch lpca = new PrivateLpcaSketch(hll, 1.0, new TestingRandomizedResponse());
+
+        for (int b = 0; b < lpca.getNumberOfBuckets(); b++) {
+            lpca.setBit(b, true);
+            assertTrue(getBit(lpca, b));
+            lpca.setBit(b, false);
+            assertFalse(getBit(lpca, b));
+        }
+    }
+
+    @Test
+    public void testFlipBit()
+    {
+        HyperLogLog hll = HyperLogLog.newInstance(32);
+        PrivateLpcaSketch lpca = new PrivateLpcaSketch(hll, 1.0, new TestingRandomizedResponse());
+
+        lpca.setBit(10, true);
+        assertTrue(getBit(lpca, 10));
+        lpca.flipBit(10);
+        assertFalse(getBit(lpca, 10));
+        lpca.flipBit(10);
+        assertTrue(getBit(lpca, 10));
+    }
+
+    @Test
+    public void testBitProportion()
+    {
+        HyperLogLog hll = HyperLogLog.newInstance(32);
+        PrivateLpcaSketch lpca = new PrivateLpcaSketch(hll, 1.0, new TestingRandomizedResponse());
+
+        int cutoff = 18;
+        for (int i = 0; i < lpca.getNumberOfBuckets(); i++) {
+            lpca.setBit(i, i < cutoff);
+        }
+
+        assertEquals(lpca.getRawBitProportion(), 18.0 / 32.0);
+    }
+
+    private boolean getBit(PrivateLpcaSketch lpca, int bucket)
+    {
+        int b = PrivateLpcaSketch.bitmapByteIndex(bucket);
+        int shift = PrivateLpcaSketch.bitmapBitShift(bucket);
+
+        return ((lpca.getBitmap()[b] >> shift) & 1) == 1;
+    }
+
+    private int[] getBucketValues(HyperLogLog hll)
+    {
+        int[] values = new int[hll.getNumberOfBuckets()];
+        hll.eachBucket((i, value) -> values[i] = value);
+        return values;
+    }
+}

--- a/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestingRandomizedResponse.java
+++ b/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestingRandomizedResponse.java
@@ -13,23 +13,19 @@
  */
 package com.facebook.airlift.stats.cardinality;
 
-enum Format
+/**
+ * More like UN-randomized response. This one won't flip any bits!
+ */
+public class TestingRandomizedResponse
+        implements RandomizedResponseStrategy
 {
-    SPARSE_V1(0),
-    DENSE_V1(1),
-    SPARSE_V2(2),
-    DENSE_V2(3),
-    PRIVATE_LPCA_V1(4);
-
-    private byte tag;
-
-    Format(int tag)
+    public double effectiveProbability(double flipProbability)
     {
-        this.tag = (byte) tag;
+        return 0.0;
     }
 
-    public byte getTag()
+    public boolean shouldFlip(double flipProbability)
     {
-        return tag;
+        return false;
     }
 }


### PR DESCRIPTION
`PrivateLpcaSketch` is essentially a privacy-preserving analog to the existing `HyperLogLog` sketch. Where `HyperLogLog` stores small integer values in each bucket, `PrivateLpcaSketch` stores only a single bit indicating whether the corresponding value is above or below a threshold fixed at initialization. This minimization, combined with some additional noise, yields a sketch from which it is considerably more difficult to identify an individual value's presence or absence. Because of the relationship between `PrivateLpcaSketch` and `HyperLogLog`, the former is always created (or updated) from the latter. (In short, a `HyperLogLog` is privatized to a `PrivateLpcaSketch`.)