### PR TITLE
Add unit tests to clarify HyperLogLog behavior

### DIFF
--- a/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestSparseHll.java
+++ b/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestSparseHll.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static com.facebook.airlift.stats.cardinality.TestUtils.createHashForBucket;
 import static com.facebook.airlift.stats.cardinality.TestUtils.sequence;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.testing.SliceAssertions.assertSlicesEqual;
@@ -29,6 +30,45 @@ import static org.testng.Assert.assertEquals;
 public class TestSparseHll
 {
     private static final int SPARSE_HLL_INSTANCE_SIZE = ClassLayout.parseClass(SparseHll.class).instanceSize();
+
+    @Test(dataProvider = "bits")
+    public void testCorrectNumberOfZeros(int indexBitLength)
+    {
+        SparseHll sparseHll = new SparseHll(indexBitLength);
+        // Note: the peculiar minus six in the following line reflects a surprising edge case.
+        // See https://github.com/prestodb/airlift/issues/56.
+        int limit = Math.min(Long.SIZE - indexBitLength - 6, Utils.numberOfBuckets(indexBitLength));
+        for (int i = 0; i < limit; i++) {
+            // insert a hash for bucket i that has i leading zeros
+            sparseHll.insertHash(createHashForBucket(indexBitLength, i, i));
+        }
+
+        // each non-empty bucket should have value index + 1
+        sparseHll.eachBucket((i, value) -> assertEquals(value, i + 1));
+    }
+
+    @Test(dataProvider = "bits")
+    public void testCorrectNumberOfZerosOnUpdate(int indexBitLength)
+    {
+        SparseHll sparseHll = new SparseHll(indexBitLength);
+        int limit = Math.min(Long.SIZE - indexBitLength - 6, Utils.numberOfBuckets(indexBitLength));
+        for (int i = 0; i < limit; i++) {
+            // insert a hash for bucket i that has no leading zeros
+            sparseHll.insertHash(createHashForBucket(indexBitLength, i, 0));
+        }
+        for (int i = 0; i < limit; i++) {
+            // insert a hash for bucket i that has i leading zeros
+            sparseHll.insertHash(createHashForBucket(indexBitLength, i, i));
+        }
+
+        // each bucket from 0 to limit should have value index + 1
+        // Note: SparseHll may return multiple values for each bucket, so we keep track of the largest only.
+        int[] values = new int[limit];
+        sparseHll.eachBucket((i, value) -> values[i] = Math.max(values[i], value));
+        for (int i = 0; i < limit; i++) {
+            assertEquals(values[i], i + 1);
+        }
+    }
 
     @Test(dataProvider = "bits")
     public void testMerge(int prefixBitLength)

--- a/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestUtils.java
+++ b/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestUtils.java
@@ -31,4 +31,13 @@ public final class TestUtils
 
         return builder.build();
     }
+
+    public static long createHashForBucket(int indexBitLength, int bucket, int leadingZeros)
+    {
+        // put a 1 in the indexBitLength + i + 1-th place
+        long hash = 1L << (Long.SIZE - (indexBitLength + leadingZeros + 1));
+        // set index bits to corresponding bucket index
+        hash |= (long) bucket << (Long.SIZE - indexBitLength);
+        return hash;
+    }
 }


### PR DESCRIPTION
This commit makes no functional changes and only adds tests. Beyond merely improving test
coverage, this commit serves as partial documentation of one minor (but surprising) edge case (#56) and a
verification of behavior that was contested in #42.

Test plan: 

These tests pass. 😄 