### PR TITLE
Make jetty/CachedDistribution class public

### DIFF
--- a/http-client/src/main/java/com/facebook/airlift/http/client/jetty/CachedDistribution.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/jetty/CachedDistribution.java
@@ -16,7 +16,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * todo remove this when https://github.com/martint/jmxutils/issues/26 is implemented
  */
 @ThreadSafe
-class CachedDistribution
+public class CachedDistribution
 {
     private final Supplier<Distribution> distributionSupplier;
 


### PR DESCRIPTION
Currently, class CachedDistribution has package access that make it
impossible for other application (such as Presto) to query JMX metrics. 
Making it public resolves the issue.
