### PR TITLE
Add a new config in HttpServerConfig to set sniHostCheck

### DIFF
--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServer.java
@@ -223,7 +223,7 @@ public class HttpServer
         ServerConnector httpsConnector;
         if (config.isHttpsEnabled()) {
             HttpConfiguration httpsConfiguration = new HttpConfiguration(baseHttpConfiguration);
-            httpsConfiguration.addCustomizer(new SecureRequestCustomizer());
+            httpsConfiguration.addCustomizer(new SecureRequestCustomizer(config.isSniHostCheck()));
 
             SslContextFactory sslContextFactory = new SslContextFactory();
             Optional<KeyStore> pemKeyStore = tryLoadPemKeyStore(config);

--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerConfig.java
@@ -72,6 +72,7 @@ public class HttpServerConfig
     private int httpAcceptQueueSize = 8000;
 
     private boolean httpsEnabled;
+    private boolean sniHostCheck = true;
     private int httpsPort = 8443;
     private String keystorePath;
     private String keystorePassword;
@@ -176,6 +177,18 @@ public class HttpServerConfig
     {
         this.httpsEnabled = httpsEnabled;
         return this;
+    }
+
+    @Config("http-server.https.sni-host-check")
+    public HttpServerConfig setSniHostCheck(boolean sniHostCheck)
+    {
+        this.sniHostCheck = sniHostCheck;
+        return this;
+    }
+
+    public boolean isSniHostCheck()
+    {
+        return sniHostCheck;
     }
 
     public int getHttpsPort()

--- a/http-server/src/test/java/com/facebook/airlift/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/TestHttpServerConfig.java
@@ -87,7 +87,8 @@ public class TestHttpServerConfig
                 .setAuthorizationEnabled(false)
                 .setDefaultAuthorizationPolicy(HttpServerConfig.AuthorizationPolicy.ALLOW)
                 .setDefaultAllowedRoles("")
-                .setAllowUnsecureRequestsInAuthorizer(false));
+                .setAllowUnsecureRequestsInAuthorizer(false)
+                .setSniHostCheck(true));
     }
 
     @Test
@@ -143,6 +144,7 @@ public class TestHttpServerConfig
                 .put("http-server.authorization.default-policy", "DENY")
                 .put("http-server.authorization.default-allowed-roles", "user, internal, admin")
                 .put("http-server.authorization.allow-unsecured-requests", "true")
+                .put("http-server.https.sni-host-check", "false")
                 .build();
 
         HttpServerConfig expected = new HttpServerConfig()
@@ -194,7 +196,8 @@ public class TestHttpServerConfig
                 .setAuthorizationEnabled(true)
                 .setDefaultAuthorizationPolicy(HttpServerConfig.AuthorizationPolicy.DENY)
                 .setDefaultAllowedRoles("user, internal, admin")
-                .setAllowUnsecureRequestsInAuthorizer(true);
+                .setAllowUnsecureRequestsInAuthorizer(true)
+                .setSniHostCheck(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add a new config http-server.https.sni-host-check to set the sniHostCheck without making it to true by default.