### PR TITLE
Add prefix to java invocation in launcher script

### DIFF
--- a/launcher/src/main/scripts/bin/launcher.py
+++ b/launcher/src/main/scripts/bin/launcher.py
@@ -211,7 +211,10 @@ def build_java_execution(options, daemon):
     system_properties = ['-D%s=%s' % i for i in properties.items()]
     classpath = pathjoin(options.install_path, 'lib', '*')
 
-    command = ['java', '-cp', classpath]
+    java_binary_prefix = ''
+    if os.getenv('JAVA_HOME'):
+        java_binary_prefix = os.getenv('JAVA_HOME') + '/bin/'
+    command = [java_binary_prefix + 'java', '-cp', classpath]
     command += jvm_properties + system_properties
     command += [main_class]
     command += options.arguments


### PR DESCRIPTION
Currently, the launcher script invokes java binary directly. This makes it suscpetible to whichever java is installed on the system/PATH variable. We want to invoke it with a prefix (valeu of $JAVA_HOME) so that the caller can control which java version needs to be used