### PR TITLE
Fix javadoc error

### DIFF
--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/SfmSketch.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/SfmSketch.java
@@ -31,7 +31,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * SfmSketch is created in a non-private mode. Privacy must be enabled through the enablePrivacy() function.
  * Once made private, the sketch becomes immutable. Privacy is quantified by the parameter epsilon.
  * <p>
- * When epsilon > 0, the sketch is epsilon-DP, and bits are randomized to preserve privacy.
+ * When epsilon is greater than 0, the sketch is epsilon-DP, and bits are randomized to preserve privacy.
  * When epsilon == NON_PRIVATE_EPSILON, the sketch is not private, and bits are set deterministically.
  * <p>
  * The best accuracy comes with NON_PRIVATE_EPSILON. For private epsilons, larger gives more accuracy,


### PR DESCRIPTION
```
error: bad use of '>'
    [ERROR]  * When epsilon > 0, the sketch is epsilon-DP, and bits are randomized to preserve privacy.
```

^ This should bypass this error in javadoc. Lets see