### PR TITLE
Resolve Configuration Property Conflict in Presto for logs

### DIFF
--- a/launcher/src/main/scripts/bin/launcher.py
+++ b/launcher/src/main/scripts/bin/launcher.py
@@ -195,7 +195,7 @@ def build_java_execution(options, daemon):
         properties['log.levels-file'] = options.log_levels
 
     if daemon:
-        properties['log.output-file'] = options.server_log
+        properties['log.path'] = options.server_log
         properties['log.enable-console'] = 'false'
 
     jvm_properties = load_lines(options.jvm_config)
@@ -373,7 +373,7 @@ def parse_properties(parser, args):
         key, value = [i.strip() for i in arg.split('=', 1)]
         if key == 'config':
             parser.error('cannot specify config using -D option (use --config)')
-        if key == 'log.output-file':
+        if key == 'log.path':
             parser.error('cannot specify server log using -D option (use --server-log-file)')
         if key == 'log.levels-file':
             parser.error('cannot specify log levels using -D option (use --log-levels-file)')


### PR DESCRIPTION
Resolve Configuration Property Conflict in Presto

**Description**
This change resolves a configuration property conflict in Presto between 'log.output-file' and 'log.path'. Both properties were trying to set the location of the log file, leading to a configuration error. The resolution involves recommending the use of 'log.path' over the legacy 'log.output-file'.

**Motivation**
While configuring Presto, a conflict was encountered where 'log.output-file' and 'log.path' were both trying to set the log file's location with different values. This led to a configuration error that hindered the proper functioning of Presto.

**Context**
The error message received was:

Error: Configuration property 'log.output-file' conflicts with property 'log.path'
The method setLogPath(String logPath) was annotated with both @LegacyConfig("log.output-file") and @config("log.path"). This meant it could be configured with either 'log.output-file' or 'log.path'. However, only one of them should be in the configuration file, not both.

**Implementation**
The solution proposed is to recommend the use of 'log.path' in the error message as 'log.output-file' is marked as a legacy configuration. If 'log.output-file' is no longer recommended, consider deprecating or removing it in future versions.

**Impact**
This change will prevent the configuration error from occurring in the future, making Presto easier to configure and use.

**Test Plan**
Manually test the configuration of Presto after the change to ensure that the error no longer occurs. 

<img width="543" alt="Screenshot 2024-02-28 at 10 08 01 AM" src="https://github.com/prestodb/airlift/assets/89628774/3c851c71-fba2-4a5a-b37b-63cee11b21ec">
<img width="718" alt="Screenshot 2024-02-28 at 10 08 29 AM" src="https://github.com/prestodb/airlift/assets/89628774/d27a7fdf-d5f5-44d4-af50-1d2a24abb8ef">

![image](https://github.com/prestodb/airlift/assets/89628774/4d88f38c-8723-4c81-ab57-210ecc0438ca)

