### PR TITLE
Enhancement to respect user-defined log.path in launcher.py

### DIFF
--- a/launcher/src/main/scripts/bin/launcher.py
+++ b/launcher/src/main/scripts/bin/launcher.py
@@ -432,11 +432,13 @@ def main():
         node_properties = load_properties(o.node_config)
 
     data_dir = node_properties.get('node.data-dir')
+    server_dir = node_properties.get('log.path')
     o.data_dir = realpath(options.data_dir or data_dir or o.install_path)
+    o.server_dir = realpath(getattr(options, 'server_dir', None) or server_dir or pathjoin(o.data_dir, 'var/log/server.log'))
 
     o.pid_file = realpath(options.pid_file or pathjoin(o.data_dir, 'var/run/launcher.pid'))
     o.launcher_log = realpath(options.launcher_log_file or pathjoin(o.data_dir, 'var/log/launcher.log'))
-    o.server_log = realpath(options.server_log_file or pathjoin(o.data_dir, 'var/log/server.log'))
+    o.server_log = realpath(o.server_dir or options.server_log_file or pathjoin(o.data_dir, 'var/log/server.log'))
 
     o.properties = parse_properties(parser, options.properties or {})
     for k, v in node_properties.items():


### PR DESCRIPTION
This PR addresses an enhancement in launcher.py to handle the log.path setting from node.properties. Currently, regardless of the value set for log.path in node.properties, the launcher.py script always uses the default value. This behavior is not correct as it does not respect the user's configuration.

Context:

This issue arises when launcher.py is run and the log.path is explicitly provided by the user in node.properties. The script does not respect this setting and continues to use the default value.

Motivation:

The motivation for this enhancement is to respect the user's explicit configuration of log.path in node.properties. The user should have the ability to control the configuration from their end. This change will make the script more adaptable to different user configurations and improve the user experience.

Understanding:

To implement this enhancement, the o.server_dir variable, which is used to construct the server log path, is set to the value of log.path from node.properties when it's explicitly provided by the user. This allows the user's setting to override the default value.

If log.path is not provided in node.properties, o.server_dir is set to a default path. This ensures that o.server_dir is always a valid path, even when log.path is not provided.




Details:

The issue arises when the log.path is explicitly set by the user in node.properties and the service is restarted. Despite the user's explicit configuration, the system prints pid -Dlog.path=<default> instead of the user-defined value.
<img width="543" alt="Screenshot 2024-02-28 at 10 08 01 AM" src="https://github.com/prestodb/airlift/assets/89628774/3c851c71-fba2-4a5a-b37b-63cee11b21ec">
<img width="718" alt="Screenshot 2024-02-28 at 10 08 29 AM" src="https://github.com/prestodb/airlift/assets/89628774/d27a7fdf-d5f5-44d4-af50-1d2a24abb8ef">

![image](https://github.com/prestodb/airlift/assets/89628774/4d88f38c-8723-4c81-ab57-210ecc0438ca)



Test plan :
<img width="353" alt="Screenshot 2024-03-22 at 12 10 57 PM" src="https://github.com/prestodb/airlift/assets/89628774/4a80020f-00ea-4dcd-8dd7-64db24bf9406">
<img width="314" alt="Screenshot 2024-03-22 at 12 11 41 PM" src="https://github.com/prestodb/airlift/assets/89628774/47f34e1e-0a60-4c4f-bcb2-7a5daf2a57c9">





