### PR TITLE
Add environment variable substitution to node config

### DIFF
--- a/node/pom.xml
+++ b/node/pom.xml
@@ -59,5 +59,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-</project>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <phase>test</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <environmentVariables>
+                        <TEST_PREFIX>test</TEST_PREFIX>
+                        <TEST_ENVIRONMENT>environment</TEST_ENVIRONMENT>
+                        <TEST_POOL>pool</TEST_POOL>
+                        <TEST_NODE_ID>node-id</TEST_NODE_ID>
+                        <TEST_LOCATION>location</TEST_LOCATION>
+                        <TEST_NODE_INTERNAL_ADDRESS>node-internal-address</TEST_NODE_INTERNAL_ADDRESS>
+                        <TEST_NODE_EXTERNAL_ADDRESS>node-external-address</TEST_NODE_EXTERNAL_ADDRESS>
+                        <TEST_NODE_BIND_IP>10.11.12.13</TEST_NODE_BIND_IP>
+                        <TEST_BINARY_SPEC>binary-spec</TEST_BINARY_SPEC>
+                        <TEST_CONFIG_SPEC>config-spec</TEST_CONFIG_SPEC>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Ignore class com.facebook.airlift.node.NodeConfig because StringBuffer is used-->
+                    <ignoreClassNamePatterns>com.facebook.airlift.node.NodeConfig</ignoreClassNamePatterns>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/node/src/test/java/com/facebook/airlift/node/TestNodeConfig.java
+++ b/node/src/test/java/com/facebook/airlift/node/TestNodeConfig.java
@@ -30,6 +30,7 @@ import static com.facebook.airlift.node.NodeConfig.AddressSource.HOSTNAME;
 import static com.facebook.airlift.node.NodeConfig.AddressSource.IP;
 import static com.facebook.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static com.facebook.airlift.testing.ValidationAssertions.assertValidates;
+import static org.testng.Assert.assertEquals;
 
 public class TestNodeConfig
 {
@@ -78,6 +79,54 @@ public class TestNodeConfig
                 .setInternalAddressSource(HOSTNAME);
 
         ConfigAssertions.assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testSingleEnvironmentVariableSubstitution()
+    {
+        NodeConfig config = new NodeConfig()
+                .setEnvironment("${ENV:TEST_ENVIRONMENT}")
+                .setPool("${ENV:TEST_POOL}")
+                .setNodeId("${ENV:TEST_NODE_ID}")
+                .setLocation("${ENV:TEST_LOCATION}")
+                .setNodeInternalAddress("${ENV:TEST_NODE_INTERNAL_ADDRESS}")
+                .setNodeExternalAddress("${ENV:TEST_NODE_EXTERNAL_ADDRESS}")
+                .setNodeBindIp("${ENV:TEST_NODE_BIND_IP}")
+                .setBinarySpec("${ENV:TEST_BINARY_SPEC}")
+                .setConfigSpec("${ENV:TEST_CONFIG_SPEC}");
+
+        assertEquals(config.getEnvironment(), "environment");
+        assertEquals(config.getPool(), "pool");
+        assertEquals(config.getNodeId(), "node-id");
+        assertEquals(config.getLocation(), "location");
+        assertEquals(config.getNodeInternalAddress(), "node-internal-address");
+        assertEquals(config.getNodeExternalAddress(), "node-external-address");
+        assertEquals(config.getNodeBindIp().getHostAddress(), "10.11.12.13");
+        assertEquals(config.getBinarySpec(), "binary-spec");
+        assertEquals(config.getConfigSpec(), "config-spec");
+    }
+
+    @Test
+    public void testMultipleEnvironmentVariableSubstitution()
+    {
+        NodeConfig config = new NodeConfig()
+                .setEnvironment("${ENV:TEST_PREFIX}-${ENV:TEST_ENVIRONMENT}")
+                .setPool("${ENV:TEST_PREFIX}-${ENV:TEST_POOL}")
+                .setNodeId("${ENV:TEST_PREFIX}-${ENV:TEST_NODE_ID}")
+                .setLocation("${ENV:TEST_PREFIX}-${ENV:TEST_LOCATION}")
+                .setNodeInternalAddress("${ENV:TEST_PREFIX}-${ENV:TEST_NODE_INTERNAL_ADDRESS}")
+                .setNodeExternalAddress("${ENV:TEST_PREFIX}-${ENV:TEST_NODE_EXTERNAL_ADDRESS}")
+                .setBinarySpec("${ENV:TEST_PREFIX}-${ENV:TEST_BINARY_SPEC}")
+                .setConfigSpec("${ENV:TEST_PREFIX}-${ENV:TEST_CONFIG_SPEC}");
+
+        assertEquals(config.getEnvironment(), "test-environment");
+        assertEquals(config.getPool(), "test-pool");
+        assertEquals(config.getNodeId(), "test-node-id");
+        assertEquals(config.getLocation(), "test-location");
+        assertEquals(config.getNodeInternalAddress(), "test-node-internal-address");
+        assertEquals(config.getNodeExternalAddress(), "test-node-external-address");
+        assertEquals(config.getBinarySpec(), "test-binary-spec");
+        assertEquals(config.getConfigSpec(), "test-config-spec");
     }
 
     @Test


### PR DESCRIPTION
### Description

The PR adds environment variable substitution support to `node.properties` config.
For instance, the following config is valid:
```
node.id=${ENV:HOSTNAME}
node.environment=${ENV:ENVIRONMENT}
node.data-dir=${ENV:DATA_DIR}
```
The change is needed in order to be able to initialize node configs by runtime values in environments where it is impossible to change `node.properties` file, for example if the process is running by non-root user or file is not editable because of other reasons (`ConfigMap` mounted as file in Kubernetes).

### Test

```shell
mvn -f node/pom.xml test

[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< com.facebook.airlift:node >----------------------
[INFO] Building node 0.210-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------

...

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.796 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.424 s
[INFO] Finished at: 2024-03-31T18:41:25+02:00
[INFO] ------------------------------------------------------------------------

...

Process finished with exit code 0
```