### PR TITLE
Close PrintStream properly in TestConfigurationLoader tests

### DIFF
--- a/configuration/src/test/java/com/facebook/airlift/configuration/TestConfigurationLoader.java
+++ b/configuration/src/test/java/com/facebook/airlift/configuration/TestConfigurationLoader.java
@@ -68,22 +68,18 @@ public class TestConfigurationLoader
             throws IOException
     {
         final File file = File.createTempFile("config", ".properties", tempDir);
-        PrintStream out = new PrintStream(new FileOutputStream(file));
-        try {
+        try (PrintStream out = new PrintStream(new FileOutputStream(file))) {
             out.print("test: foo");
+
+            System.setProperty("config", file.getAbsolutePath());
+
+            Map<String, String> properties = loadProperties();
+
+            assertEquals(properties.get("test"), "foo");
+            assertEquals(properties.get("config"), file.getAbsolutePath());
+
+            System.getProperties().remove("config");
         }
-        catch (Exception e) {
-            out.close();
-        }
-
-        System.setProperty("config", file.getAbsolutePath());
-
-        Map<String, String> properties = loadProperties();
-
-        assertEquals(properties.get("test"), "foo");
-        assertEquals(properties.get("config"), file.getAbsolutePath());
-
-        System.getProperties().remove("config");
     }
 
     @Test
@@ -91,24 +87,20 @@ public class TestConfigurationLoader
             throws IOException
     {
         final File file = File.createTempFile("config", ".properties", tempDir);
-        PrintStream out = new PrintStream(new FileOutputStream(file));
-        try {
+        try (PrintStream out = new PrintStream(new FileOutputStream(file))) {
             out.println("key1: original");
             out.println("key2: original");
+
+            System.setProperty("config", file.getAbsolutePath());
+            System.setProperty("key1", "overridden");
+
+            Map<String, String> properties = loadProperties();
+
+            assertEquals(properties.get("config"), file.getAbsolutePath());
+            assertEquals(properties.get("key1"), "overridden");
+            assertEquals(properties.get("key2"), "original");
+
+            System.getProperties().remove("config");
         }
-        catch (Exception e) {
-            out.close();
-        }
-
-        System.setProperty("config", file.getAbsolutePath());
-        System.setProperty("key1", "overridden");
-
-        Map<String, String> properties = loadProperties();
-
-        assertEquals(properties.get("config"), file.getAbsolutePath());
-        assertEquals(properties.get("key1"), "overridden");
-        assertEquals(properties.get("key2"), "original");
-
-        System.getProperties().remove("config");
     }
 }


### PR DESCRIPTION
The PR fixes the issue in `com.facebook.airlift.configuration.TestConfigurationLoader`. Tests `testLoadsFromFile()` and `testSystemOverridesFile()` open `PrintStream` and close it only if an `Exception` occurred.
The tests cannot be completed successfully, because of exception in `teardown()` method.

The fix closes `PrintStream` in any way by using `try-with-resources` statement.

**Before**
```shell
$ mvn -f configuration/pom.xml test
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------< com.facebook.airlift:configuration >-----------------
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
[ERROR] Tests run: 119, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.435 s <<< FAILURE! - in TestSuite
[ERROR] teardown(com.facebook.airlift.configuration.TestConfigurationLoader)  Time elapsed: 0.016 s  <<< FAILURE!
java.nio.file.FileSystemException: C:\Users\dnskr\AppData\Local\Temp\1713707499451-0: failed to delete one or more files; see suppressed exceptions for details
        at com.google.common.io.MoreFiles.throwDeleteFailed(MoreFiles.java:785)
        ...
        Suppressed: java.nio.file.FileSystemException: C:\Users\dnskr\AppData\Local\Temp\1713707499451-0\config13441979576855912152.properties: The process cannot access the file because it is being used by another process.

                at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:92)
                at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
                at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
                at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:270)
                at java.base/sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:105)
                at java.base/java.nio.file.Files.delete(Files.java:1141)
                at com.google.common.io.MoreFiles.deleteRecursivelyInsecure(MoreFiles.java:672)
                at com.google.common.io.MoreFiles.deleteDirectoryContentsInsecure(MoreFiles.java:691)
                at com.google.common.io.MoreFiles.deleteRecursivelyInsecure(MoreFiles.java:665)
                at com.google.common.io.MoreFiles.deleteRecursively(MoreFiles.java:540)
                ... 30 more
[INFO] 
[INFO] Results:
[INFO]
[ERROR] Failures: 
[ERROR]   TestConfigurationLoader.teardown:50 » FileSystem C:\Users\dnskr\AppData\Local\...
[INFO]
[ERROR] Tests run: 119, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.026 s
[INFO] Finished at: 2024-04-21T15:51:40+02:00
[INFO] ------------------------------------------------------------------------
```

**After**
```shell
$ mvn -f configuration/pom.xml test
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------< com.facebook.airlift:configuration >-----------------
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
[INFO] Tests run: 118, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.487 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO]
[INFO] Tests run: 118, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.806 s
[INFO] Finished at: 2024-04-21T15:53:14+02:00
[INFO] ------------------------------------------------------------------------
```