### PR TITLE
Fix CVE-2011-1473 by disabling client renegotiation

### DIFF
--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServer.java
@@ -256,6 +256,7 @@ public class HttpServer
             sslContextFactory.setWantClientAuth(true);
             sslContextFactory.setSslSessionTimeout((int) config.getSslSessionTimeout().getValue(SECONDS));
             sslContextFactory.setSslSessionCacheSize(config.getSslSessionCacheSize());
+            sslContextFactory.setRenegotiationAllowed(false);
             SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory, "http/1.1");
 
             Integer acceptors = config.getHttpsAcceptorThreads();


### PR DESCRIPTION
The upstream airlift fixed the security vulnerability with PR https://github.com/airlift/airlift/pull/1293

[CVE-2011-1473](https://github.com/advisories/GHSA-5wj2-7gqw-v6cm)

This is a backport of the fix.