### PR TITLE
Add extra headers for static resources

### DIFF
--- a/http-server/src/main/java/com/facebook/airlift/http/server/ClassPathResourceHandler.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/ClassPathResourceHandler.java
@@ -16,6 +16,7 @@
 package com.facebook.airlift.http.server;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.HttpHeaders;
 import org.eclipse.jetty.http.HttpMethod;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -54,13 +56,14 @@ public class ClassPathResourceHandler
     private final String baseUri; // "" or "/foo"
     private final String classPathResourceBase;
     private final List<String> welcomeFiles;
+    private final Map<String, String> extraHeaders;
 
     public ClassPathResourceHandler(String baseUri, String classPathResourceBase, String... welcomeFiles)
     {
-        this(baseUri, classPathResourceBase, ImmutableList.copyOf(welcomeFiles));
+        this(baseUri, classPathResourceBase, ImmutableList.copyOf(welcomeFiles), ImmutableMap.of());
     }
 
-    public ClassPathResourceHandler(String baseUri, String classPathResourceBase, List<String> welcomeFiles)
+    public ClassPathResourceHandler(String baseUri, String classPathResourceBase, List<String> welcomeFiles, Map<String, String> extraHeaders)
     {
         requireNonNull(baseUri, "baseUri is null");
         requireNonNull(classPathResourceBase, "classPathResourceBase is null");
@@ -81,6 +84,7 @@ public class ClassPathResourceHandler
             files.add(welcomeFile);
         }
         this.welcomeFiles = files.build();
+        this.extraHeaders = ImmutableMap.copyOf(extraHeaders);
     }
 
     @Override
@@ -129,6 +133,7 @@ public class ClassPathResourceHandler
 
             String contentType = MIME_TYPES.getMimeByExtension(resource.toString());
             response.setContentType(contentType);
+            extraHeaders.forEach((name, value) -> response.setHeader(name, value));
 
             if (skipContent) {
                 return;

--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServer.java
@@ -366,7 +366,11 @@ public class HttpServer
 
         for (HttpResourceBinding resource : resources) {
             GzipHandler gzipHandler = new GzipHandler();
-            gzipHandler.setHandler(new ClassPathResourceHandler(resource.getBaseUri(), resource.getClassPathResourceBase(), resource.getWelcomeFiles()));
+            gzipHandler.setHandler(new ClassPathResourceHandler(
+                    resource.getBaseUri(),
+                    resource.getClassPathResourceBase(),
+                    resource.getWelcomeFiles(),
+                    resource.getExtraHeaders()));
             handlers.addHandler(gzipHandler);
         }
 

--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerBinder.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerBinder.java
@@ -1,11 +1,14 @@
 package com.facebook.airlift.http.server;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.util.Objects.requireNonNull;
@@ -43,6 +46,7 @@ public class HttpServerBinder
         private final String baseUri;
         private final String classPathResourceBase;
         private final List<String> welcomeFiles = new ArrayList<>();
+        private final Map<String, String> extraHeaders = new HashMap<>();
 
         public HttpResourceBinding(String baseUri, String classPathResourceBase)
         {
@@ -68,6 +72,17 @@ public class HttpServerBinder
         public HttpResourceBinding withWelcomeFile(String welcomeFile)
         {
             welcomeFiles.add(welcomeFile);
+            return this;
+        }
+
+        public Map<String, String> getExtraHeaders()
+        {
+            return ImmutableMap.copyOf(extraHeaders);
+        }
+
+        public HttpResourceBinding withExtraHeader(String name, String value)
+        {
+            extraHeaders.put(name, value);
             return this;
         }
     }


### PR DESCRIPTION
Allow users to add extra headers when using the
`HttpResourceBinding` for static resources.