### PR TITLE
Add discovery-server

### DIFF
--- a/discovery-server/README.txt
+++ b/discovery-server/README.txt
@@ -1,0 +1,1 @@
+Discovery service

--- a/discovery-server/etc/config.properties
+++ b/discovery-server/etc/config.properties
@@ -1,0 +1,4 @@
+node.environment=test
+http-server.http.port=8411
+node.id=597A741E-9968-40E2-BB4D-7AF26DE18689
+service-inventory.uri=http://localhost/~martin/service-inventory.json

--- a/discovery-server/etc/config2.properties
+++ b/discovery-server/etc/config2.properties
@@ -1,0 +1,4 @@
+node.environment=test
+http-server.http.port=8412
+node.id=0BA42FDB-5DBA-4A2C-BE26-9596B7B4368E
+service-inventory.uri=http://localhost/~martin/service-inventory.json

--- a/discovery-server/etc/service-inventory.json
+++ b/discovery-server/etc/service-inventory.json
@@ -1,0 +1,27 @@
+{
+    "environment": "test",
+    "services": [
+        {
+            "id": "C8A9EE64-0476-452C-8638-8E72F3EE3CA6",
+            "nodeId": "597A741E-9968-40E2-BB4D-7AF26DE18689",
+            "type": "discovery",
+            "pool": "general",
+            "location": "/localhost",
+            "state": "RUNNING",
+            "properties": {
+                "http": "http://localhost:8411"
+            }
+        },
+        {
+            "id": "370AF416-5F44-47D3-BFB6-D93A92676D49",
+            "nodeId": "0BA42FDB-5DBA-4A2C-BE26-9596B7B4368E",
+            "type": "discovery",
+            "pool": "general",
+            "location": "/localhost",
+            "state": "RUNNING",
+            "properties": {
+                "http": "http://localhost:8412"
+            }
+        }
+    ]
+}

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -122,7 +122,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
+            <groupId>com.facebook.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.airlift</groupId>
+        <artifactId>airlift</artifactId>
+        <version>0.217-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>discovery-server</artifactId>
+    <name>discovery-server</name>
+    <description>Discovery server</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <main-class>com.facebook.airlift.discovery.server.DiscoveryServer</main-class>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>jmx-http-rpc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-smile</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.iq80.leveldb</groupId>
+            <artifactId>leveldb-api</artifactId>
+            <version>0.10</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.iq80.leveldb</groupId>
+            <artifactId>leveldb</artifactId>
+            <version>0.10</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>discovery</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>node</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>trace-token</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>event</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>jmx</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>discovery-server</artifactId>
+    <packaging>jar</packaging>
     <name>discovery-server</name>
     <description>Discovery server</description>
 
@@ -169,7 +170,6 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
-
 
         <!-- for testing -->
         <dependency>

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryConfig.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class DiscoveryConfig
+{
+    private Duration maxAge = new Duration(30, TimeUnit.SECONDS);
+    private Duration storeCacheTtl = new Duration(1, TimeUnit.SECONDS);
+
+    @NotNull
+    public Duration getMaxAge()
+    {
+        return maxAge;
+    }
+
+    @Config("discovery.max-age")
+    public DiscoveryConfig setMaxAge(Duration maxAge)
+    {
+        this.maxAge = maxAge;
+        return this;
+    }
+
+    @NotNull
+    public Duration getStoreCacheTtl()
+    {
+        return storeCacheTtl;
+    }
+
+    @Config("discovery.store-cache-ttl")
+    public DiscoveryConfig setStoreCacheTtl(Duration storeCacheTtl)
+    {
+        this.storeCacheTtl = storeCacheTtl;
+        return this;
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryConfig.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryConfig.java
@@ -16,7 +16,7 @@
 package com.facebook.airlift.discovery.server;
 
 import com.facebook.airlift.configuration.Config;
-import io.airlift.units.Duration;
+import com.facebook.airlift.units.Duration;
 
 import javax.validation.constraints.NotNull;
 

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryServer.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryServer.java
@@ -50,8 +50,7 @@ public final class DiscoveryServer
                     new DiscoveryServerModule(),
                     new HttpEventModule(),
                     new TraceTokenModule(),
-                    new DiscoveryModule()
-            );
+                    new DiscoveryModule());
 
             Injector injector = app.initialize();
             injector.getInstance(Announcer.class).start();

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryServer.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryServer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.discovery.client.Announcer;
+import com.facebook.airlift.discovery.client.DiscoveryModule;
+import com.facebook.airlift.event.client.HttpEventModule;
+import com.facebook.airlift.http.server.HttpServerModule;
+import com.facebook.airlift.jaxrs.JaxrsModule;
+import com.facebook.airlift.jmx.JmxModule;
+import com.facebook.airlift.jmx.http.rpc.JmxHttpRpcModule;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.node.NodeModule;
+import com.facebook.airlift.tracetoken.TraceTokenModule;
+import com.google.inject.Injector;
+import org.weakref.jmx.guice.MBeanModule;
+
+public final class DiscoveryServer
+{
+    private static final Logger log = Logger.get(DiscoveryServer.class);
+
+    private DiscoveryServer() {}
+
+    public static void main(String[] args)
+    {
+        try {
+            Bootstrap app = new Bootstrap(
+                    new MBeanModule(),
+                    new NodeModule(),
+                    new HttpServerModule(),
+                    new JaxrsModule(true),
+                    new JsonModule(),
+                    new JmxModule(),
+                    new JmxHttpRpcModule(),
+                    new DiscoveryServerModule(),
+                    new HttpEventModule(),
+                    new TraceTokenModule(),
+                    new DiscoveryModule()
+            );
+
+            Injector injector = app.initialize();
+            injector.getInstance(Announcer.class).start();
+        }
+        catch (Throwable t) {
+            log.error(t);
+            System.exit(1);
+        }
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryServerModule.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryServerModule.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.discovery.client.ServiceSelector;
+import com.facebook.airlift.discovery.store.InMemoryStore;
+import com.facebook.airlift.discovery.store.PersistentStore;
+import com.facebook.airlift.discovery.store.PersistentStoreConfig;
+import com.facebook.airlift.discovery.store.ReplicatedStoreModule;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
+import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+
+public class DiscoveryServerModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(DiscoveryConfig.class);
+        jaxrsBinder(binder).bind(ServiceResource.class);
+
+        discoveryBinder(binder).bindHttpAnnouncement("discovery");
+
+        jsonCodecBinder(binder).bindJsonCodec(Service.class);
+        jsonCodecBinder(binder).bindListJsonCodec(Service.class);
+
+        binder.bind(ServiceSelector.class).to(DiscoveryServiceSelector.class);
+
+        // dynamic announcements
+        jaxrsBinder(binder).bind(DynamicAnnouncementResource.class);
+        binder.bind(DynamicStore.class).to(ReplicatedDynamicStore.class).in(Scopes.SINGLETON);
+        binder.install(new ReplicatedStoreModule("dynamic", ForDynamicStore.class, InMemoryStore.class));
+
+        // static announcements
+        jaxrsBinder(binder).bind(StaticAnnouncementResource.class);
+        binder.bind(StaticStore.class).to(ReplicatedStaticStore.class).in(Scopes.SINGLETON);
+        binder.install(new ReplicatedStoreModule("static", ForStaticStore.class, PersistentStore.class));
+        configBinder(binder).bindConfig(PersistentStoreConfig.class, "static");
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryServiceSelector.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DiscoveryServiceSelector.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.discovery.client.ServiceDescriptor;
+import com.facebook.airlift.discovery.client.ServiceInventory;
+import com.facebook.airlift.discovery.client.ServiceSelector;
+import com.facebook.airlift.node.NodeInfo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.util.Objects.requireNonNull;
+
+public class DiscoveryServiceSelector
+        implements ServiceSelector
+{
+    private final NodeInfo nodeInfo;
+    private final ServiceInventory inventory;
+
+    @Inject
+    public DiscoveryServiceSelector(NodeInfo nodeInfo, ServiceInventory inventory)
+    {
+        this.nodeInfo = requireNonNull(nodeInfo, "nodeInfo is null");
+        this.inventory = requireNonNull(inventory, "inventory is null");
+    }
+
+    @Override
+    public String getType()
+    {
+        return "discovery";
+    }
+
+    @Override
+    public String getPool()
+    {
+        return nodeInfo.getPool();
+    }
+
+    @Override
+    public List<ServiceDescriptor> selectAllServices()
+    {
+        return ImmutableList.copyOf(inventory.getServiceDescriptors(getType()));
+    }
+
+    @Override
+    public ListenableFuture<List<ServiceDescriptor>> refresh()
+    {
+        // this should be async, but it is never used
+        inventory.updateServiceInventory();
+        return immediateFuture(selectAllServices());
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicAnnouncement.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicAnnouncement.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.concurrent.Immutable;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import java.util.Set;
+
+@Immutable
+public class DynamicAnnouncement
+{
+    private final String environment;
+    private final String location;
+    private final String pool;
+    private final Set<DynamicServiceAnnouncement> services;
+
+    @JsonCreator
+    public DynamicAnnouncement(
+            @JsonProperty("environment") String environment,
+            @JsonProperty("pool") String pool,
+            @JsonProperty("location") String location,
+            @JsonProperty("services") Set<DynamicServiceAnnouncement> services)
+    {
+        this.environment = environment;
+        this.location = location;
+        this.pool = pool;
+
+        if (services != null) {
+            this.services = ImmutableSet.copyOf(services);
+        }
+        else {
+            this.services = null;
+        }
+    }
+
+    @NotNull
+    public String getEnvironment()
+    {
+        return environment;
+    }
+
+    public String getLocation()
+    {
+        return location;
+    }
+
+    @NotNull
+    public String getPool()
+    {
+        return pool;
+    }
+
+    @NotNull
+    @Valid
+    public Set<DynamicServiceAnnouncement> getServiceAnnouncements()
+    {
+        return services;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DynamicAnnouncement that = (DynamicAnnouncement) o;
+
+        if (environment != null ? !environment.equals(that.environment) : that.environment != null) {
+            return false;
+        }
+        if (location != null ? !location.equals(that.location) : that.location != null) {
+            return false;
+        }
+        if (pool != null ? !pool.equals(that.pool) : that.pool != null) {
+            return false;
+        }
+        if (services != null ? !services.equals(that.services) : that.services != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = environment != null ? environment.hashCode() : 0;
+        result = 31 * result + (location != null ? location.hashCode() : 0);
+        result = 31 * result + (pool != null ? pool.hashCode() : 0);
+        result = 31 * result + (services != null ? services.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "DynamicAnnouncement{" +
+                "environment='" + environment + '\'' +
+                ", location='" + location + '\'' +
+                ", pool='" + pool + '\'' +
+                ", services=" + services +
+                '}';
+    }
+
+    public static Builder copyOf(DynamicAnnouncement announcement)
+    {
+        return new Builder().copyOf(announcement);
+    }
+
+    public static class Builder
+    {
+        private String environment;
+        private String location;
+        private String pool;
+        private Set<DynamicServiceAnnouncement> services;
+
+        public Builder copyOf(DynamicAnnouncement announcement)
+        {
+            environment = announcement.getEnvironment();
+            location = announcement.getLocation();
+            services = announcement.getServiceAnnouncements();
+            pool = announcement.getPool();
+
+            return this;
+        }
+
+        public Builder setLocation(String location)
+        {
+            this.location = location;
+            return this;
+        }
+
+        public DynamicAnnouncement build()
+        {
+            return new DynamicAnnouncement(environment, pool, location, services);
+        }
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicAnnouncementResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicAnnouncementResource.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.node.NodeInfo;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.lang.String.format;
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
+@Path("/v1/announcement/{node_id}")
+public class DynamicAnnouncementResource
+{
+    private final NodeInfo nodeInfo;
+    private final DynamicStore dynamicStore;
+
+    @Inject
+    public DynamicAnnouncementResource(DynamicStore dynamicStore, NodeInfo nodeInfo)
+    {
+        this.dynamicStore = dynamicStore;
+        this.nodeInfo = nodeInfo;
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response put(@PathParam("node_id") Id<Node> nodeId, @Context UriInfo uriInfo, DynamicAnnouncement announcement)
+    {
+        if (!nodeInfo.getEnvironment().equals(announcement.getEnvironment())) {
+            return Response.status(BAD_REQUEST)
+                    .entity(format("Environment mismatch. Expected: %s, Provided: %s", nodeInfo.getEnvironment(), announcement.getEnvironment()))
+                    .build();
+        }
+
+        String location = firstNonNull(announcement.getLocation(), "/somewhere/" + nodeId.toString());
+
+        DynamicAnnouncement announcementWithLocation = DynamicAnnouncement.copyOf(announcement)
+                .setLocation(location)
+                .build();
+
+        dynamicStore.put(nodeId, announcementWithLocation);
+
+        return Response.status(ACCEPTED).build();
+    }
+
+    @DELETE
+    public Response delete(@PathParam("node_id") Id<Node> nodeId)
+    {
+        dynamicStore.delete(nodeId);
+
+        return Response.noContent().build();
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicServiceAnnouncement.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicServiceAnnouncement.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Map;
+
+public class DynamicServiceAnnouncement
+{
+    private final Id<Service> id;
+    private final String type;
+    private final Map<String, String> properties;
+
+    @JsonCreator
+    public DynamicServiceAnnouncement(
+            @JsonProperty("id") Id<Service> id,
+            @JsonProperty("type") String type,
+            @JsonProperty("properties") Map<String, String> properties)
+    {
+        this.id = id;
+        this.type = type;
+
+        if (properties != null) {
+            this.properties = ImmutableMap.copyOf(properties);
+        }
+        else {
+            this.properties = null;
+        }
+    }
+
+    @NotNull
+    public Id<Service> getId()
+    {
+        return id;
+    }
+
+    @NotNull
+    public String getType()
+    {
+        return type;
+    }
+
+    @NotNull
+    public Map<String, String> getProperties()
+    {
+        return properties;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DynamicServiceAnnouncement that = (DynamicServiceAnnouncement) o;
+
+        if (id != null ? !id.equals(that.id) : that.id != null) {
+            return false;
+        }
+        if (properties != null ? !properties.equals(that.properties) : that.properties != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ServiceAnnouncement{" +
+                "id=" + id +
+                ", type='" + type + '\'' +
+                ", properties=" + properties +
+                '}';
+    }
+
+    public static Function<DynamicServiceAnnouncement, Service> toServiceWith(final Id<Node> nodeId, final String location, final String pool)
+    {
+        return new Function<DynamicServiceAnnouncement, Service>()
+        {
+            @Override
+            public Service apply(DynamicServiceAnnouncement announcement)
+            {
+                return new Service(announcement.getId(), nodeId, announcement.getType(), pool, location, announcement.getProperties());
+            }
+        };
+    }
+
+
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicServiceAnnouncement.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicServiceAnnouncement.java
@@ -17,12 +17,12 @@ package com.facebook.airlift.discovery.server;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 
 import javax.validation.constraints.NotNull;
 
 import java.util.Map;
+import java.util.function.Function;
 
 public class DynamicServiceAnnouncement
 {
@@ -111,13 +111,6 @@ public class DynamicServiceAnnouncement
 
     public static Function<DynamicServiceAnnouncement, Service> toServiceWith(final Id<Node> nodeId, final String location, final String pool)
     {
-        return new Function<DynamicServiceAnnouncement, Service>()
-        {
-            @Override
-            public Service apply(DynamicServiceAnnouncement announcement)
-            {
-                return new Service(announcement.getId(), nodeId, announcement.getType(), pool, location, announcement.getProperties());
-            }
-        };
+        return announcement -> new Service(announcement.getId(), nodeId, announcement.getType(), pool, location, announcement.getProperties());
     }
 }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicServiceAnnouncement.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicServiceAnnouncement.java
@@ -120,6 +120,4 @@ public class DynamicServiceAnnouncement
             }
         };
     }
-
-
 }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicStore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import java.util.Set;
+
+public interface DynamicStore
+{
+    void put(Id<Node> nodeId, DynamicAnnouncement announcement);
+    void delete(Id<Node> nodeId);
+
+    Set<Service> getAll();
+    Set<Service> get(String type);
+    Set<Service> get(String type, String pool);
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/DynamicStore.java
@@ -20,9 +20,12 @@ import java.util.Set;
 public interface DynamicStore
 {
     void put(Id<Node> nodeId, DynamicAnnouncement announcement);
+
     void delete(Id<Node> nodeId);
 
     Set<Service> getAll();
+
     Set<Service> get(String type);
+
     Set<Service> get(String type, String pool);
 }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/EmbeddedDiscoveryModule.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/EmbeddedDiscoveryModule.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.airlift.discovery.client.ServiceSelector;
+import com.facebook.airlift.discovery.store.InMemoryStore;
+import com.facebook.airlift.discovery.store.ReplicatedStoreModule;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+
+import java.util.Set;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
+import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+
+public class EmbeddedDiscoveryModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(DiscoveryConfig.class);
+        jaxrsBinder(binder).bind(ServiceResource.class);
+
+        discoveryBinder(binder).bindHttpAnnouncement("discovery");
+
+        jsonCodecBinder(binder).bindJsonCodec(Service.class);
+        jsonCodecBinder(binder).bindListJsonCodec(Service.class);
+
+        binder.bind(ServiceSelector.class).to(DiscoveryServiceSelector.class);
+        binder.bind(StaticStore.class).to(EmptyStaticStore.class);
+
+        jaxrsBinder(binder).bind(DynamicAnnouncementResource.class);
+        binder.bind(DynamicStore.class).to(ReplicatedDynamicStore.class).in(Scopes.SINGLETON);
+        binder.install(new ReplicatedStoreModule("dynamic", ForDynamicStore.class, InMemoryStore.class));
+    }
+
+    private static class EmptyStaticStore
+            implements StaticStore
+    {
+        @Override
+        public void put(Service service)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void delete(Id<Service> id)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<Service> getAll()
+        {
+            return ImmutableSet.of();
+        }
+
+        @Override
+        public Set<Service> get(String type)
+        {
+            return ImmutableSet.of();
+        }
+
+        @Override
+        public Set<Service> get(String type, String pool)
+        {
+            return ImmutableSet.of();
+        }
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ForDynamicStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ForDynamicStore.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForDynamicStore
+{
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ForStaticStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ForStaticStore.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForStaticStore
+{
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Id.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Id.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.UUID;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+@Immutable
+public final class Id<T>
+{
+    private final String id;
+
+    @JsonCreator
+    public static <T> Id<T> valueOf(String id)
+    {
+        return new Id<>(id);
+    }
+
+    public static <T> Id<T> random()
+    {
+        return new Id<>(UUID.randomUUID().toString());
+    }
+
+    private Id(String id)
+    {
+        checkNotNull(id, "id is null");
+        checkArgument(!id.isEmpty(), "id is empty");
+        this.id = id;
+    }
+
+    @JsonValue
+    public String get()
+    {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return id.equals(((Id<?>) o).id);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return id;
+    }
+
+    public byte[] getBytes()
+    {
+        return toString().getBytes(UTF_8);
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Id.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Id.java
@@ -23,8 +23,8 @@ import javax.annotation.concurrent.Immutable;
 import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 @Immutable
 public final class Id<T>
@@ -44,7 +44,7 @@ public final class Id<T>
 
     private Id(String id)
     {
-        checkNotNull(id, "id is null");
+        requireNonNull(id, "id is null");
         checkArgument(!id.isEmpty(), "id is empty");
         this.id = id;
     }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Node.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Node.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+public interface Node
+{
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedDynamicStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedDynamicStore.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.discovery.store.DistributedStore;
+import com.facebook.airlift.discovery.store.Entry;
+import com.facebook.airlift.json.JsonCodec;
+import com.google.common.base.Supplier;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.airlift.discovery.server.DynamicServiceAnnouncement.toServiceWith;
+import static com.facebook.airlift.discovery.server.Service.matchesPool;
+import static com.facebook.airlift.discovery.server.Service.matchesType;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.base.Suppliers.memoizeWithExpiration;
+import static com.google.common.collect.Iterables.filter;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class ReplicatedDynamicStore
+        implements DynamicStore
+{
+    private final DistributedStore store;
+    private final Duration maxAge;
+    private final JsonCodec<List<Service>> codec;
+    private final Supplier<Set<Service>> servicesSupplier;
+
+    @Inject
+    public ReplicatedDynamicStore(@ForDynamicStore DistributedStore store, DiscoveryConfig config, JsonCodec<List<Service>> codec)
+    {
+        this.store = checkNotNull(store, "store is null");
+        this.maxAge = checkNotNull(config, "config is null").getMaxAge();
+        this.codec = checkNotNull(codec, "codec is null");
+
+        servicesSupplier = cachingSupplier(servicesSupplier(), config.getStoreCacheTtl());
+    }
+
+    @Override
+    public void put(Id<Node> nodeId, DynamicAnnouncement announcement)
+    {
+        List<Service> services = FluentIterable.from(announcement.getServiceAnnouncements())
+                .transform(toServiceWith(nodeId, announcement.getLocation(), announcement.getPool()))
+                .toList();
+
+        byte[] key = nodeId.getBytes();
+        byte[] value = codec.toJsonBytes(services);
+
+        store.put(key, value, maxAge);
+    }
+
+    @Override
+    public void delete(Id<Node> nodeId)
+    {
+        store.delete(nodeId.getBytes());
+    }
+
+    @Override
+    public Set<Service> getAll()
+    {
+        return servicesSupplier.get();
+    }
+
+    @Override
+    public Set<Service> get(String type)
+    {
+        return ImmutableSet.copyOf(filter(getAll(), matchesType(type)));
+    }
+
+    @Override
+    public Set<Service> get(String type, String pool)
+    {
+        return ImmutableSet.copyOf(filter(getAll(), and(matchesType(type), matchesPool(pool))));
+    }
+
+    private Supplier<Set<Service>> servicesSupplier()
+    {
+        return new Supplier<Set<Service>>()
+        {
+            @Override
+            public Set<Service> get()
+            {
+                ImmutableSet.Builder<Service> builder = ImmutableSet.builder();
+                for (Entry entry : store.getAll()) {
+                    builder.addAll(codec.fromJson(entry.getValue()));
+                }
+                return builder.build();
+            }
+        };
+    }
+
+    private static <T> Supplier<T> cachingSupplier(Supplier<T> supplier, Duration ttl)
+    {
+        if (ttl.toMillis() == 0) {
+            return supplier;
+        }
+        return memoizeWithExpiration(supplier, ttl.toMillis(), MILLISECONDS);
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedDynamicStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedDynamicStore.java
@@ -18,8 +18,8 @@ package com.facebook.airlift.discovery.server;
 import com.facebook.airlift.discovery.store.DistributedStore;
 import com.facebook.airlift.discovery.store.Entry;
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.units.Duration;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.units.Duration;
 
 import javax.inject.Inject;
 

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedStaticStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedStaticStore.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.discovery.store.DistributedStore;
+import com.facebook.airlift.discovery.store.Entry;
+import com.facebook.airlift.json.JsonCodec;
+import com.google.common.collect.ImmutableSet;
+
+import javax.inject.Inject;
+
+import java.util.Set;
+
+import static com.facebook.airlift.discovery.server.Service.matchesPool;
+import static com.facebook.airlift.discovery.server.Service.matchesType;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.collect.Iterables.filter;
+
+public class ReplicatedStaticStore
+        implements StaticStore
+{
+    private final DistributedStore store;
+    private final JsonCodec<Service> codec;
+
+    @Inject
+    public ReplicatedStaticStore(@ForStaticStore DistributedStore store, JsonCodec<Service> codec)
+    {
+        this.store = checkNotNull(store, "store is null");
+        this.codec = checkNotNull(codec, "codec is null");
+    }
+
+    @Override
+    public void put(Service service)
+    {
+        byte[] key = service.getId().getBytes();
+        byte[] value = codec.toJsonBytes(service);
+
+        store.put(key, value);
+    }
+
+    @Override
+    public void delete(Id<Service> id)
+    {
+        store.delete(id.getBytes());
+    }
+
+    @Override
+    public Set<Service> getAll()
+    {
+        ImmutableSet.Builder<Service> builder = ImmutableSet.builder();
+        for (Entry entry : store.getAll()) {
+            builder.add(codec.fromJson(entry.getValue()));
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public Set<Service> get(String type)
+    {
+        return ImmutableSet.copyOf(filter(getAll(), matchesType(type)));
+    }
+
+    @Override
+    public Set<Service> get(String type, String pool)
+    {
+        return ImmutableSet.copyOf(filter(getAll(), and(matchesType(type), matchesPool(pool))));
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedStaticStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedStaticStore.java
@@ -26,9 +26,7 @@ import java.util.Set;
 
 import static com.facebook.airlift.discovery.server.Service.matchesPool;
 import static com.facebook.airlift.discovery.server.Service.matchesType;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Predicates.and;
-import static com.google.common.collect.Iterables.filter;
+import static java.util.Objects.requireNonNull;
 
 public class ReplicatedStaticStore
         implements StaticStore
@@ -39,8 +37,8 @@ public class ReplicatedStaticStore
     @Inject
     public ReplicatedStaticStore(@ForStaticStore DistributedStore store, JsonCodec<Service> codec)
     {
-        this.store = checkNotNull(store, "store is null");
-        this.codec = checkNotNull(codec, "codec is null");
+        this.store = requireNonNull(store, "store is null");
+        this.codec = requireNonNull(codec, "codec is null");
     }
 
     @Override
@@ -72,12 +70,14 @@ public class ReplicatedStaticStore
     @Override
     public Set<Service> get(String type)
     {
-        return ImmutableSet.copyOf(filter(getAll(), matchesType(type)));
+        return ImmutableSet.copyOf(getAll().stream().filter(matchesType(type)).iterator());
     }
 
     @Override
     public Set<Service> get(String type, String pool)
     {
-        return ImmutableSet.copyOf(filter(getAll(), and(matchesType(type), matchesPool(pool))));
+        return ImmutableSet.copyOf(getAll().stream()
+                .filter(service -> matchesType(type).test(service) && matchesPool(pool).test(service))
+                .iterator());
     }
 }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Service.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Service.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Map;
+
+@Immutable
+public class Service
+{
+    private final Id<Service> id;
+    private final Id<Node> nodeId;
+    private final String type;
+    private final String pool;
+    private final String location;
+    private final Map<String, String> properties;
+
+    @JsonCreator
+    public Service(
+            @JsonProperty("id") Id<Service> id,
+            @JsonProperty("nodeId") Id<Node> nodeId,
+            @JsonProperty("type") String type,
+            @JsonProperty("pool") String pool,
+            @JsonProperty("location") String location,
+            @JsonProperty("properties") Map<String, String> properties)
+    {
+        Preconditions.checkNotNull(id, "id is null");
+        Preconditions.checkNotNull(type, "type is null");
+        Preconditions.checkNotNull(pool, "pool is null");
+        Preconditions.checkNotNull(location, "location is null");
+        Preconditions.checkNotNull(properties, "properties is null");
+
+        this.id = id;
+        this.nodeId = nodeId;
+        this.type = type;
+        this.pool = pool;
+        this.location = location;
+        this.properties = ImmutableMap.copyOf(properties);
+    }
+
+    @JsonProperty
+    public Id<Service> getId()
+    {
+        return id;
+    }
+
+    @JsonProperty
+    public Id<Node> getNodeId()
+    {
+        return nodeId;
+    }
+
+    @JsonProperty
+    public String getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public String getPool()
+    {
+        return pool;
+    }
+
+    @JsonProperty
+    public String getLocation()
+    {
+        return location;
+    }
+
+    @JsonProperty
+    public Map<String, String> getProperties()
+    {
+        return properties;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Service that = (Service) o;
+
+        if (!id.equals(that.id)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return id.hashCode();
+    }
+
+
+    public static Predicate<Service> matchesType(final String type)
+    {
+        return new Predicate<Service>()
+        {
+            public boolean apply(Service descriptor)
+            {
+                return descriptor.getType().equals(type);
+            }
+        };
+    }
+
+    public static Predicate<Service> matchesPool(final String pool)
+    {
+        return new Predicate<Service>()
+        {
+            public boolean apply(Service descriptor)
+            {
+                return descriptor.getPool().equals(pool);
+            }
+        };
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Service{" +
+                "id=" + id +
+                ", nodeId=" + nodeId +
+                ", type='" + type + '\'' +
+                ", pool='" + pool + '\'' +
+                ", location='" + location + '\'' +
+                ", properties=" + properties +
+                '}';
+    }
+
+    public static Builder copyOf(StaticAnnouncement announcement)
+    {
+        return new Builder().copyOf(announcement);
+    }
+
+    public static class Builder
+    {
+        private Id<Service> id;
+        private String type;
+        private String pool;
+        private String location;
+        private Map<String, String> properties;
+
+        public Builder copyOf(StaticAnnouncement announcement)
+        {
+            type = announcement.getType();
+            pool = announcement.getPool();
+            properties = ImmutableMap.copyOf(announcement.getProperties());
+
+            return this;
+        }
+
+        public Builder setId(Id<Service> id)
+        {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setLocation(String location)
+        {
+            this.location = location;
+            return this;
+        }
+
+        public Service build()
+        {
+            // TODO: validate state
+            return new Service(id, null, type, pool, location, properties);
+        }
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Service.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Service.java
@@ -119,7 +119,6 @@ public class Service
         return id.hashCode();
     }
 
-
     public static Predicate<Service> matchesType(final String type)
     {
         return new Predicate<Service>()

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Service.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Service.java
@@ -17,13 +17,14 @@ package com.facebook.airlift.discovery.server;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Map;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class Service
@@ -44,18 +45,12 @@ public class Service
             @JsonProperty("location") String location,
             @JsonProperty("properties") Map<String, String> properties)
     {
-        Preconditions.checkNotNull(id, "id is null");
-        Preconditions.checkNotNull(type, "type is null");
-        Preconditions.checkNotNull(pool, "pool is null");
-        Preconditions.checkNotNull(location, "location is null");
-        Preconditions.checkNotNull(properties, "properties is null");
-
-        this.id = id;
+        this.id = requireNonNull(id, "id is null");
         this.nodeId = nodeId;
-        this.type = type;
-        this.pool = pool;
-        this.location = location;
-        this.properties = ImmutableMap.copyOf(properties);
+        this.type = requireNonNull(type, "type is null");
+        this.pool = requireNonNull(pool, "pool is null");
+        this.location = requireNonNull(location, "location is null");
+        this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
     }
 
     @JsonProperty
@@ -121,24 +116,12 @@ public class Service
 
     public static Predicate<Service> matchesType(final String type)
     {
-        return new Predicate<Service>()
-        {
-            public boolean apply(Service descriptor)
-            {
-                return descriptor.getType().equals(type);
-            }
-        };
+        return descriptor -> descriptor.getType().equals(type);
     }
 
     public static Predicate<Service> matchesPool(final String pool)
     {
-        return new Predicate<Service>()
-        {
-            public boolean apply(Service descriptor)
-            {
-                return descriptor.getPool().equals(pool);
-            }
-        };
+        return descriptor -> descriptor.getPool().equals(pool);
     }
 
     @Override

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ServiceResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ServiceResource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.node.NodeInfo;
+import com.google.inject.Inject;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import static com.google.common.collect.Sets.union;
+
+
+@Path("/v1/service")
+public class ServiceResource
+{
+    private final DynamicStore dynamicStore;
+    private final StaticStore staticStore;
+    private final NodeInfo node;
+
+    @Inject
+    public ServiceResource(DynamicStore dynamicStore, StaticStore staticStore, NodeInfo node)
+    {
+        this.dynamicStore = dynamicStore;
+        this.staticStore = staticStore;
+        this.node = node;
+    }
+
+    @GET
+    @Path("{type}/{pool}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Services getServices(@PathParam("type") String type, @PathParam("pool") String pool)
+    {
+        return new Services(node.getEnvironment(), union(dynamicStore.get(type, pool), staticStore.get(type, pool)));
+    }
+
+    @GET
+    @Path("{type}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Services getServices(@PathParam("type") String type)
+    {
+        return new Services(node.getEnvironment(), union(dynamicStore.get(type), staticStore.get(type)));
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Services getServices()
+    {
+        return new Services(node.getEnvironment(), union(dynamicStore.getAll(), staticStore.getAll()));
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ServiceResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ServiceResource.java
@@ -26,7 +26,6 @@ import javax.ws.rs.core.MediaType;
 
 import static com.google.common.collect.Sets.union;
 
-
 @Path("/v1/service")
 public class ServiceResource
 {

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Services.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Services.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Set;
+
+@Immutable
+public class Services
+{
+    private final String environment;
+    private final Set<Service> services;
+
+    public Services(String environment, Set<Service> services)
+    {
+        Preconditions.checkNotNull(environment, "environment is null");
+        Preconditions.checkNotNull(services, "services is null");
+
+        this.environment = environment;
+        this.services = ImmutableSet.copyOf(services);
+    }
+
+    @JsonProperty
+    public String getEnvironment()
+    {
+        return environment;
+    }
+
+    @JsonProperty
+    public Set<Service> getServices()
+    {
+        return services;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Services services1 = (Services) o;
+
+        if (!environment.equals(services1.environment)) {
+            return false;
+        }
+        if (!services.equals(services1.services)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = environment.hashCode();
+        result = 31 * result + services.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Services{" +
+                "environment='" + environment + '\'' +
+                ", services=" + services +
+                '}';
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Services.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/Services.java
@@ -16,12 +16,13 @@
 package com.facebook.airlift.discovery.server;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.concurrent.Immutable;
 
 import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class Services
@@ -31,11 +32,8 @@ public class Services
 
     public Services(String environment, Set<Service> services)
     {
-        Preconditions.checkNotNull(environment, "environment is null");
-        Preconditions.checkNotNull(services, "services is null");
-
-        this.environment = environment;
-        this.services = ImmutableSet.copyOf(services);
+        this.environment = requireNonNull(environment, "environment is null");
+        this.services = ImmutableSet.copyOf(requireNonNull(services, "services is null"));
     }
 
     @JsonProperty

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticAnnouncement.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticAnnouncement.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Map;
+
+public class StaticAnnouncement
+{
+    private final String environment;
+    private final String location;
+    private final String type;
+    private final String pool;
+    private final Map<String, String> properties;
+
+    @JsonCreator
+    public StaticAnnouncement(
+            @JsonProperty("environment") String environment,
+            @JsonProperty("type") String type,
+            @JsonProperty("pool") String pool,
+            @JsonProperty("location") String location,
+            @JsonProperty("properties") Map<String, String> properties)
+    {
+        this.environment = environment;
+        this.location = location;
+        this.type = type;
+        this.pool = pool;
+
+        if (properties != null) {
+            this.properties = ImmutableMap.copyOf(properties);
+        }
+        else {
+            this.properties = null;
+        }
+    }
+
+    @NotNull
+    public String getEnvironment()
+    {
+        return environment;
+    }
+
+    public String getLocation()
+    {
+        return location;
+    }
+
+    @NotNull
+    public String getType()
+    {
+        return type;
+    }
+
+    @NotNull
+    public String getPool()
+    {
+        return pool;
+    }
+
+    @NotNull
+    public Map<String, String> getProperties()
+    {
+        return properties;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        StaticAnnouncement that = (StaticAnnouncement) o;
+
+        if (environment != null ? !environment.equals(that.environment) : that.environment != null) {
+            return false;
+        }
+        if (location != null ? !location.equals(that.location) : that.location != null) {
+            return false;
+        }
+        if (pool != null ? !pool.equals(that.pool) : that.pool != null) {
+            return false;
+        }
+        if (properties != null ? !properties.equals(that.properties) : that.properties != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = environment != null ? environment.hashCode() : 0;
+        result = 31 * result + (location != null ? location.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
+        result = 31 * result + (pool != null ? pool.hashCode() : 0);
+        result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        return result;
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticAnnouncementResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticAnnouncementResource.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.node.NodeInfo;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import java.net.URI;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.lang.String.format;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
+@Path("/v1/announcement/static")
+public class StaticAnnouncementResource
+{
+    private final StaticStore store;
+    private final NodeInfo nodeInfo;
+
+    @Inject
+    public StaticAnnouncementResource(StaticStore store, NodeInfo nodeInfo)
+    {
+        this.store = store;
+        this.nodeInfo = nodeInfo;
+    }
+
+    @POST
+    @Consumes("application/json")
+    @Produces("application/json")
+    public Response post(StaticAnnouncement announcement, @Context UriInfo uriInfo)
+    {
+        if (!nodeInfo.getEnvironment().equals(announcement.getEnvironment())) {
+            return Response.status(BAD_REQUEST)
+                    .entity(format("Environment mismatch. Expected: %s, Provided: %s", nodeInfo.getEnvironment(), announcement.getEnvironment()))
+                    .build();
+        }
+
+        Id<Service> id = Id.random();
+        String location = firstNonNull(announcement.getLocation(), "/somewhere/" + id);
+
+        Service service = Service.copyOf(announcement)
+                    .setId(id)
+                    .setLocation(location)
+                    .build();
+
+        store.put(service);
+
+        URI uri = UriBuilder.fromUri(uriInfo.getBaseUri()).path(StaticAnnouncementResource.class).path("{id}").build(id);
+        return Response.created(uri).entity(service).build();
+    }
+
+    @GET
+    @Produces("application/json")
+    public Services get()
+    {
+        return new Services(nodeInfo.getEnvironment(), store.getAll());
+    }
+
+    @DELETE
+    @Path("{id}")
+    public void delete(@PathParam("id") Id<Service> id)
+    {
+        store.delete(id);
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticAnnouncementResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticAnnouncementResource.java
@@ -64,9 +64,9 @@ public class StaticAnnouncementResource
         String location = firstNonNull(announcement.getLocation(), "/somewhere/" + id);
 
         Service service = Service.copyOf(announcement)
-                    .setId(id)
-                    .setLocation(location)
-                    .build();
+                .setId(id)
+                .setLocation(location)
+                .build();
 
         store.put(service);
 

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticStore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import java.util.Set;
+
+public interface StaticStore
+{
+    void put(Service service);
+    void delete(Id<Service> id);
+
+    Set<Service> getAll();
+    Set<Service> get(String type);
+    Set<Service> get(String type, String pool);
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/StaticStore.java
@@ -20,9 +20,12 @@ import java.util.Set;
 public interface StaticStore
 {
     void put(Service service);
+
     void delete(Id<Service> id);
 
     Set<Service> getAll();
+
     Set<Service> get(String type);
+
     Set<Service> get(String type, String pool);
 }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/testing/TestingDiscoveryServer.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/testing/TestingDiscoveryServer.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server.testing;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.airlift.discovery.client.DiscoveryModule;
+import com.facebook.airlift.discovery.server.EmbeddedDiscoveryModule;
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.airlift.http.server.testing.TestingHttpServerModule;
+import com.facebook.airlift.jaxrs.JaxrsModule;
+import com.facebook.airlift.jmx.testing.TestingJmxModule;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.google.inject.Injector;
+import org.weakref.jmx.guice.MBeanModule;
+
+import java.net.URI;
+
+public class TestingDiscoveryServer
+        implements AutoCloseable
+{
+    private final LifeCycleManager lifeCycleManager;
+    private final TestingHttpServer server;
+
+    public TestingDiscoveryServer(String environment)
+            throws Exception
+    {
+        Bootstrap app = new Bootstrap(
+                new MBeanModule(),
+                new TestingNodeModule(environment),
+                new TestingHttpServerModule(),
+                new JsonModule(),
+                new JaxrsModule(true),
+                new TestingJmxModule(),
+                new DiscoveryModule(),
+                new EmbeddedDiscoveryModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperty("discovery.store-cache-ttl", "0ms")
+                .quiet()
+                .initialize();
+
+        lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+
+        server = injector.getInstance(TestingHttpServer.class);
+    }
+
+    public URI getBaseUrl()
+    {
+        return server.getBaseUrl();
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        if (lifeCycleManager != null) {
+            lifeCycleManager.stop();
+        }
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/BatchProcessor.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/BatchProcessor.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.facebook.airlift.log.Logger;
+import com.google.common.base.Preconditions;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
+public class BatchProcessor<T>
+{
+    private final static Logger log = Logger.get(BatchProcessor.class);
+
+    private final BatchHandler<T> handler;
+    private final int maxBatchSize;
+    private final BlockingQueue<T> queue;
+    private final String name;
+
+    private ExecutorService executor;
+    private volatile Future<?> future;
+
+    private final AtomicLong processedEntries = new AtomicLong();
+    private final AtomicLong droppedEntries = new AtomicLong();
+    private final AtomicLong errors = new AtomicLong();
+
+    public BatchProcessor(String name, BatchHandler<T> handler, int maxBatchSize, int queueSize)
+    {
+        Preconditions.checkNotNull(name, "name is null");
+        Preconditions.checkNotNull(handler, "handler is null");
+        Preconditions.checkArgument(queueSize > 0, "queue size needs to be a positive integer");
+        Preconditions.checkArgument(maxBatchSize > 0, "max batch size needs to be a positive integer");
+
+        this.name = name;
+        this.handler = handler;
+        this.maxBatchSize = maxBatchSize;
+        this.queue = new ArrayBlockingQueue<T>(queueSize);
+    }
+
+    @PostConstruct
+    public synchronized void start()
+    {
+        if (future == null) {
+            executor = newSingleThreadExecutor(threadsNamed("batch-processor-" + name));
+
+            future = executor.submit(new Runnable() {
+                public void run()
+                {
+                    while (!Thread.interrupted()) {
+                        final List<T> entries = new ArrayList<T>(maxBatchSize);
+
+                        try {
+                            T first = queue.take();
+                            entries.add(first);
+                            queue.drainTo(entries, maxBatchSize - 1);
+
+                            handler.processBatch(Collections.unmodifiableList(entries));
+
+                            processedEntries.addAndGet(entries.size());
+                        }
+                        catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        catch (Throwable t) {
+                            errors.incrementAndGet();
+                            log.warn(t, "Error handling batch");
+                        }
+
+                        // TODO: expose timestamp of last execution via jmx
+                    }
+                }
+            });
+        }
+    }
+
+    @Managed
+    public long getProcessedEntries()
+    {
+        return processedEntries.get();
+    }
+
+    @Managed
+    public long getDroppedEntries()
+    {
+        return droppedEntries.get();
+    }
+
+    @Managed
+    public long getErrors()
+    {
+        return errors.get();
+    }
+
+    @Managed
+    public long getQueueSize()
+    {
+        return queue.size();
+    }
+
+    @PreDestroy
+    public synchronized void stop()
+    {
+        if (future != null) {
+            future.cancel(true);
+            executor.shutdownNow();
+
+            future = null;
+        }
+    }
+
+    public void put(T entry)
+    {
+        Preconditions.checkState(!future.isCancelled(), "Processor is not running");
+        Preconditions.checkNotNull(entry, "entry is null");
+
+        while (!queue.offer(entry)) {
+            // throw away oldest and try again
+            if (queue.poll() != null) {
+                droppedEntries.incrementAndGet();
+            }
+        }
+    }
+
+    public static interface BatchHandler<T>
+    {
+        void processBatch(Collection<T> entries);
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/BatchProcessor.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/BatchProcessor.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
 public class BatchProcessor<T>
@@ -53,8 +54,8 @@ public class BatchProcessor<T>
 
     public BatchProcessor(String name, BatchHandler<T> handler, int maxBatchSize, int queueSize)
     {
-        Preconditions.checkNotNull(name, "name is null");
-        Preconditions.checkNotNull(handler, "handler is null");
+        requireNonNull(name, "name is null");
+        requireNonNull(handler, "handler is null");
         Preconditions.checkArgument(queueSize > 0, "queue size needs to be a positive integer");
         Preconditions.checkArgument(maxBatchSize > 0, "max batch size needs to be a positive integer");
 
@@ -139,7 +140,7 @@ public class BatchProcessor<T>
     public void put(T entry)
     {
         Preconditions.checkState(!future.isCancelled(), "Processor is not running");
-        Preconditions.checkNotNull(entry, "entry is null");
+        requireNonNull(entry, "entry is null");
 
         while (!queue.offer(entry)) {
             // throw away oldest and try again

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/BatchProcessor.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/BatchProcessor.java
@@ -37,7 +37,7 @@ import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
 public class BatchProcessor<T>
 {
-    private final static Logger log = Logger.get(BatchProcessor.class);
+    private static final Logger log = Logger.get(BatchProcessor.class);
 
     private final BatchHandler<T> handler;
     private final int maxBatchSize;
@@ -70,7 +70,8 @@ public class BatchProcessor<T>
         if (future == null) {
             executor = newSingleThreadExecutor(threadsNamed("batch-processor-" + name));
 
-            future = executor.submit(new Runnable() {
+            future = executor.submit(new Runnable()
+            {
                 public void run()
                 {
                     while (!Thread.interrupted()) {

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ConflictResolver.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ConflictResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+public class ConflictResolver
+{
+    public Entry resolve(Entry a, Entry b)
+    {
+        switch (a.getVersion().compare(b.getVersion())) {
+            case BEFORE:
+                return b;
+            case AFTER:
+                return a;
+        }
+
+        return a; // arbitrary
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/DistributedStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/DistributedStore.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Iterables;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.Arrays;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.base.Predicates.not;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+/**
+ * A simple, eventually consistent, fully replicated, distributed key-value store.
+ */
+public class DistributedStore
+{
+    private final String name;
+    private final LocalStore localStore;
+    private final RemoteStore remoteStore;
+    private final Supplier<DateTime> timeSupplier;
+    private final Duration tombstoneMaxAge;
+    private final Duration garbageCollectionInterval;
+
+    private final ScheduledExecutorService garbageCollector;
+    private final AtomicLong lastGcTimestamp = new AtomicLong();
+
+    @Inject
+    public DistributedStore(
+            String name,
+            LocalStore localStore,
+            RemoteStore remoteStore,
+            StoreConfig config,
+            Supplier<DateTime> timeSupplier)
+    {
+        this.name = checkNotNull(name, "name is null");
+        this.localStore = checkNotNull(localStore, "localStore is null");
+        this.remoteStore = checkNotNull(remoteStore, "remoteStore is null");
+        this.timeSupplier = checkNotNull(timeSupplier, "timeSupplier is null");
+
+        checkNotNull(config, "config is null");
+        tombstoneMaxAge = config.getTombstoneMaxAge();
+        garbageCollectionInterval = config.getGarbageCollectionInterval();
+
+        garbageCollector = newSingleThreadScheduledExecutor(daemonThreadsNamed("distributed-store-gc-" + name));
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        garbageCollector.scheduleAtFixedRate(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                removeExpiredEntries();
+            }
+        }, 0, garbageCollectionInterval.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Managed
+    public String getName()
+    {
+        return name;
+    }
+
+    @Managed
+    public long getLastGcTimestamp()
+    {
+        return lastGcTimestamp.get();
+    }
+
+    @Managed
+    public void removeExpiredEntries()
+    {
+        for (Entry entry : localStore.getAll()) {
+            if (isExpired(entry)) {
+                localStore.delete(entry.getKey(), entry.getVersion());
+            }
+        }
+
+        lastGcTimestamp.set(System.currentTimeMillis());
+    }
+
+    private boolean isExpired(Entry entry)
+    {
+        long ageInMs = timeSupplier.get().getMillis() - entry.getTimestamp();
+
+        return entry.getValue() == null && ageInMs > tombstoneMaxAge.toMillis() ||  // TODO: this is repeated in StoreResource
+                entry.getMaxAgeInMs() != null && ageInMs > entry.getMaxAgeInMs();
+    }
+
+    @PreDestroy
+    public void shutdown()
+    {
+        garbageCollector.shutdownNow();
+    }
+
+    public void put(byte[] key, byte[] value)
+    {
+        checkNotNull(key, "key is null");
+        checkNotNull(value, "value is null");
+
+        long now = timeSupplier.get().getMillis();
+
+        Entry entry = new Entry(key, value, new Version(now), now, null);
+
+        localStore.put(entry);
+        remoteStore.put(entry);
+    }
+
+    public void put(byte[] key, byte[] value, Duration maxAge)
+    {
+        checkNotNull(key, "key is null");
+        checkNotNull(value, "value is null");
+        checkNotNull(maxAge, "maxAge is null");
+
+        long now = timeSupplier.get().getMillis();
+
+        Entry entry = new Entry(key, value, new Version(now), now, maxAge.toMillis());
+
+        localStore.put(entry);
+        remoteStore.put(entry);
+    }
+
+    public byte[] get(byte[] key)
+    {
+        checkNotNull(key, "key is null");
+
+        Entry entry = localStore.get(key);
+
+        byte[] result = null;
+        if (entry != null && entry.getValue() != null && !isExpired(entry)) {
+            result = Arrays.copyOf(entry.getValue(), entry.getValue().length);
+        }
+
+        return result;
+    }
+
+    public void delete(byte[] key)
+    {
+        checkNotNull(key, "key is null");
+
+        long now = timeSupplier.get().getMillis();
+
+        Entry entry = new Entry(key, null, new Version(now), now, null);
+
+        localStore.put(entry);
+        remoteStore.put(entry);
+    }
+
+    public Iterable<Entry> getAll()
+    {
+        return Iterables.filter(localStore.getAll(), and(not(expired()), not(tombstone())));
+    }
+
+    private Predicate<? super Entry> expired()
+    {
+        return new Predicate<Entry>()
+        {
+            public boolean apply(Entry entry)
+            {
+                return isExpired(entry);
+            }
+        };
+    }
+
+    private static Predicate<? super Entry> tombstone()
+    {
+        return new Predicate<Entry>()
+        {
+            public boolean apply(Entry entry)
+            {
+                return entry.getValue() == null;
+            }
+        };
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/DistributedStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/DistributedStore.java
@@ -15,8 +15,8 @@
  */
 package com.facebook.airlift.discovery.store;
 
+import com.facebook.airlift.units.Duration;
 import com.google.common.collect.Streams;
-import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 
 import javax.annotation.PostConstruct;

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Entry.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Entry.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Arrays;
+
+@Immutable
+public class Entry
+{
+    private final byte[] key;
+    private final byte[] value;
+    private final Version version;
+    private final long timestamp;
+    private final Long maxAgeInMs;
+
+    @JsonCreator
+    public Entry(@JsonProperty("key") byte[] key,
+            @JsonProperty("value") byte[] value,
+            @JsonProperty("version") Version version, 
+            @JsonProperty("timestamp") long timestamp,
+            @JsonProperty("maxAge") Long maxAgeInMs)
+    {
+        Preconditions.checkNotNull(key, "key is null");
+        Preconditions.checkNotNull(version, "version is null");
+        Preconditions.checkArgument(maxAgeInMs == null || maxAgeInMs > 0, "maxAgeInMs must be greater than 0");
+
+        this.value = value;
+        this.key = key;
+        this.timestamp = timestamp;
+        this.maxAgeInMs = maxAgeInMs;
+        this.version = version;
+    }
+
+    @JsonProperty
+    public byte[] getKey()
+    {
+        return key;
+    }
+
+    @JsonProperty
+    public byte[] getValue()
+    {
+        return value;
+    }
+
+    @JsonProperty
+    public Version getVersion()
+    {
+        return version;
+    }
+
+    @JsonProperty
+    public long getTimestamp()
+    {
+        return timestamp;
+    }
+
+    @JsonProperty
+    public Long getMaxAgeInMs()
+    {
+        return maxAgeInMs;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Entry entry = (Entry) o;
+
+        if (timestamp != entry.timestamp) {
+            return false;
+        }
+        if (!Arrays.equals(key, entry.key)) {
+            return false;
+        }
+        if (maxAgeInMs != null ? !maxAgeInMs.equals(entry.maxAgeInMs) : entry.maxAgeInMs != null) {
+            return false;
+        }
+        if (!Arrays.equals(value, entry.value)) {
+            return false;
+        }
+        if (!version.equals(entry.version)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = Arrays.hashCode(key);
+        result = 31 * result + (value != null ? Arrays.hashCode(value) : 0);
+        result = 31 * result + version.hashCode();
+        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = 31 * result + (maxAgeInMs != null ? maxAgeInMs.hashCode() : 0);
+        return result;
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Entry.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Entry.java
@@ -35,7 +35,7 @@ public class Entry
     @JsonCreator
     public Entry(@JsonProperty("key") byte[] key,
             @JsonProperty("value") byte[] value,
-            @JsonProperty("version") Version version, 
+            @JsonProperty("version") Version version,
             @JsonProperty("timestamp") long timestamp,
             @JsonProperty("maxAge") Long maxAgeInMs)
     {

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Entry.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Entry.java
@@ -23,6 +23,8 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.Arrays;
 
+import static java.util.Objects.requireNonNull;
+
 @Immutable
 public class Entry
 {
@@ -39,8 +41,8 @@ public class Entry
             @JsonProperty("timestamp") long timestamp,
             @JsonProperty("maxAge") Long maxAgeInMs)
     {
-        Preconditions.checkNotNull(key, "key is null");
-        Preconditions.checkNotNull(version, "version is null");
+        requireNonNull(key, "key is null");
+        requireNonNull(version, "version is null");
         Preconditions.checkArgument(maxAgeInMs == null || maxAgeInMs > 0, "maxAgeInMs must be greater than 0");
 
         this.value = value;

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/HttpRemoteStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/HttpRemoteStore.java
@@ -86,7 +86,6 @@ public class HttpRemoteStore
     private final AtomicLong lastRemoteServerRefreshTimestamp = new AtomicLong();
     private final MBeanExporter mbeanExporter;
 
-
     @Inject
     public HttpRemoteStore(String name,
             NodeInfo node,
@@ -146,8 +145,10 @@ public class HttpRemoteStore
                 // schedule a task to shut down all processors and wait for it to complete. We rely on the executor
                 // having a *single* thread to guarantee the execution happens after any currently running task
                 // (in case the cancel call above didn't do its magic and the scheduled task is still running)
-                executor.submit(new Runnable() {
-                    public void run() {
+                executor.submit(new Runnable()
+                {
+                    public void run()
+                    {
                         updateProcessors(Collections.<ServiceDescriptor>emptyList());
                     }
                 }).get();
@@ -256,7 +257,8 @@ public class HttpRemoteStore
 
                     .setUri(uri)
                     .setHeader("Content-Type", "application/x-jackson-smile")
-                    .setBodyGenerator(new BodyGenerator() {
+                    .setBodyGenerator(new BodyGenerator()
+                    {
                         @Override
                         public void write(OutputStream out)
                                 throws Exception

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/HttpRemoteStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/HttpRemoteStore.java
@@ -22,9 +22,9 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.node.NodeInfo;
+import com.facebook.airlift.units.Duration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
-import io.airlift.units.Duration;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.Managed;
 

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/HttpRemoteStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/HttpRemoteStore.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.facebook.airlift.discovery.client.ServiceDescriptor;
+import com.facebook.airlift.discovery.client.ServiceSelector;
+import com.facebook.airlift.http.client.BodyGenerator;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.node.NodeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.base.Predicates.compose;
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.base.Predicates.in;
+import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.inject.name.Names.named;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+
+public class HttpRemoteStore
+        implements RemoteStore
+{
+    private static final Logger log = Logger.get(HttpRemoteStore.class);
+
+    private final int maxBatchSize;
+    private final int queueSize;
+    private final Duration updateInterval;
+
+    private final ConcurrentMap<String, BatchProcessor<Entry>> processors = new ConcurrentHashMap<>();
+    private final String name;
+    private final NodeInfo node;
+    private final ServiceSelector selector;
+    private final HttpClient httpClient;
+
+    private Future<?> future;
+    private ScheduledExecutorService executor;
+
+    private final AtomicLong lastRemoteServerRefreshTimestamp = new AtomicLong();
+    private final MBeanExporter mbeanExporter;
+
+
+    @Inject
+    public HttpRemoteStore(String name,
+            NodeInfo node,
+            ServiceSelector selector,
+            StoreConfig config,
+            HttpClient httpClient,
+            MBeanExporter mbeanExporter)
+    {
+        Preconditions.checkNotNull(name, "name is null");
+        Preconditions.checkNotNull(node, "node is null");
+        Preconditions.checkNotNull(selector, "selector is null");
+        Preconditions.checkNotNull(httpClient, "httpClient is null");
+        Preconditions.checkNotNull(config, "config is null");
+        Preconditions.checkNotNull(mbeanExporter, "mBeanExporter is null");
+
+        this.name = name;
+        this.node = node;
+        this.selector = selector;
+        this.httpClient = httpClient;
+        this.mbeanExporter = mbeanExporter;
+
+        maxBatchSize = config.getMaxBatchSize();
+        queueSize = config.getQueueSize();
+        updateInterval = config.getRemoteUpdateInterval();
+    }
+
+    @PostConstruct
+    public synchronized void start()
+    {
+        if (future == null) {
+            // note: this *must* be single threaded for the shutdown logic to work correctly
+            executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("http-remote-store-" + name));
+
+            future = executor.scheduleWithFixedDelay(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    try {
+                        updateProcessors(selector.selectAllServices());
+                    }
+                    catch (Throwable e) {
+                        log.warn(e, "Error refreshing batch processors");
+                    }
+                }
+            }, 0, updateInterval.toMillis(), TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @PreDestroy
+    public synchronized void shutdown()
+    {
+        if (future != null) {
+            future.cancel(true);
+
+            try {
+                // schedule a task to shut down all processors and wait for it to complete. We rely on the executor
+                // having a *single* thread to guarantee the execution happens after any currently running task
+                // (in case the cancel call above didn't do its magic and the scheduled task is still running)
+                executor.submit(new Runnable() {
+                    public void run() {
+                        updateProcessors(Collections.<ServiceDescriptor>emptyList());
+                    }
+                }).get();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+
+            executor.shutdownNow();
+
+            future = null;
+        }
+    }
+
+    private void updateProcessors(List<ServiceDescriptor> descriptors)
+    {
+        Set<String> nodeIds = ImmutableSet.copyOf(transform(descriptors, getNodeIdFunction()));
+
+        // remove old ones
+        Iterator<Map.Entry<String, BatchProcessor<Entry>>> iterator = processors.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, BatchProcessor<Entry>> entry = iterator.next();
+
+            if (!nodeIds.contains(entry.getKey())) {
+                iterator.remove();
+                entry.getValue().stop();
+                mbeanExporter.unexport(nameFor(entry.getKey()));
+            }
+        }
+
+        Predicate<ServiceDescriptor> predicate = compose(and(not(equalTo(node.getNodeId())), not(in(processors.keySet()))), getNodeIdFunction());
+        Iterable<ServiceDescriptor> newDescriptors = filter(descriptors, predicate);
+
+        for (ServiceDescriptor descriptor : newDescriptors) {
+            BatchProcessor<Entry> processor = new BatchProcessor<Entry>(descriptor.getNodeId(),
+                    new MyBatchHandler(name, descriptor, httpClient),
+                    maxBatchSize,
+                    queueSize);
+
+            processor.start();
+            processors.put(descriptor.getNodeId(), processor);
+            mbeanExporter.export(nameFor(descriptor.getNodeId()), processor);
+        }
+
+        lastRemoteServerRefreshTimestamp.set(System.currentTimeMillis());
+    }
+
+    private String nameFor(String id)
+    {
+        return generatedNameOf(BatchProcessor.class, named(name + "-" + id));
+    }
+
+    @Managed
+    public long getLastRemoteServerRefreshTimestamp()
+    {
+        return lastRemoteServerRefreshTimestamp.get();
+    }
+
+    private static Function<ServiceDescriptor, String> getNodeIdFunction()
+    {
+        return new Function<ServiceDescriptor, String>()
+        {
+            public String apply(ServiceDescriptor descriptor)
+            {
+                return descriptor.getNodeId();
+            }
+        };
+    }
+
+    @Override
+    public void put(Entry entry)
+    {
+        for (BatchProcessor<Entry> processor : processors.values()) {
+            processor.put(entry);
+        }
+    }
+
+    private static class MyBatchHandler
+            implements BatchProcessor.BatchHandler<Entry>
+    {
+        private final ObjectMapper mapper = new ObjectMapper(new SmileFactory());
+
+        private final URI uri;
+        private final HttpClient httpClient;
+
+        public MyBatchHandler(String name, ServiceDescriptor descriptor, HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+
+            // TODO: build URI from resource class
+            if (descriptor.getProperties().get("https") != null) {
+                uri = URI.create(descriptor.getProperties().get("https") + "/v1/store/" + name);
+            }
+            else {
+                uri = URI.create(descriptor.getProperties().get("http") + "/v1/store/" + name);
+            }
+        }
+
+        @Override
+        public void processBatch(final Collection<Entry> entries)
+        {
+            final Request request = Request.Builder.preparePost()
+
+                    .setUri(uri)
+                    .setHeader("Content-Type", "application/x-jackson-smile")
+                    .setBodyGenerator(new BodyGenerator() {
+                        @Override
+                        public void write(OutputStream out)
+                                throws Exception
+                        {
+                            mapper.writeValue(out, entries);
+                        }
+                    })
+                    .build();
+
+            try {
+                httpClient.execute(request, createStatusResponseHandler());
+            }
+            catch (RuntimeException e) {
+                // ignore
+            }
+        }
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/InMemoryStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/InMemoryStore.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.google.common.base.Preconditions;
+
+import javax.inject.Inject;
+
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.facebook.airlift.discovery.store.Version.Occurs.AFTER;
+import static com.facebook.airlift.discovery.store.Version.Occurs.SAME;
+
+public class InMemoryStore
+        implements LocalStore
+{
+    private final ConcurrentMap<ByteBuffer, Entry> map = new ConcurrentHashMap<ByteBuffer, Entry>();
+    private final ConflictResolver resolver;
+
+    @Inject
+    public InMemoryStore(ConflictResolver resolver)
+    {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void put(Entry entry)
+    {
+        ByteBuffer key = ByteBuffer.wrap(entry.getKey());
+
+        boolean done = false;
+        while (!done) {
+            Entry old = map.putIfAbsent(key, entry);
+
+            done = true;
+            if (old != null) {
+                entry = resolver.resolve(old, entry);
+
+                if (entry != old) {
+                    done = map.replace(key, old, entry);
+                }
+            }
+        }
+    }
+
+    @Override
+    public Entry get(byte[] key)
+    {
+        Preconditions.checkNotNull(key, "key is null");
+
+        return map.get(ByteBuffer.wrap(key));
+    }
+
+    @Override
+    public void delete(byte[] key, Version version)
+    {
+        Preconditions.checkNotNull(key, "key is null");
+
+        ByteBuffer wrappedKey = ByteBuffer.wrap(key);
+
+        boolean done = false;
+        while (!done) {
+            Entry old = map.get(wrappedKey);
+
+            done = true;
+            if (old != null && EnumSet.of(AFTER, SAME).contains(version.compare(old.getVersion()))) {
+                done = map.remove(wrappedKey, old);
+            }
+        }
+    }
+
+    @Override
+    public Iterable<Entry> getAll()
+    {
+        return map.values();
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/InMemoryStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/InMemoryStore.java
@@ -15,8 +15,6 @@
  */
 package com.facebook.airlift.discovery.store;
 
-import com.google.common.base.Preconditions;
-
 import javax.inject.Inject;
 
 import java.nio.ByteBuffer;
@@ -26,6 +24,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.facebook.airlift.discovery.store.Version.Occurs.AFTER;
 import static com.facebook.airlift.discovery.store.Version.Occurs.SAME;
+import static java.util.Objects.requireNonNull;
 
 public class InMemoryStore
         implements LocalStore
@@ -62,7 +61,7 @@ public class InMemoryStore
     @Override
     public Entry get(byte[] key)
     {
-        Preconditions.checkNotNull(key, "key is null");
+        requireNonNull(key, "key is null");
 
         return map.get(ByteBuffer.wrap(key));
     }
@@ -70,7 +69,7 @@ public class InMemoryStore
     @Override
     public void delete(byte[] key, Version version)
     {
-        Preconditions.checkNotNull(key, "key is null");
+        requireNonNull(key, "key is null");
 
         ByteBuffer wrappedKey = ByteBuffer.wrap(key);
 

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/LocalStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/LocalStore.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+public interface LocalStore
+{
+    void put(Entry entry);
+    Entry get(byte[] key);
+    void delete(byte[] key, Version version);
+    Iterable<Entry> getAll();
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/LocalStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/LocalStore.java
@@ -18,7 +18,10 @@ package com.facebook.airlift.discovery.store;
 public interface LocalStore
 {
     void put(Entry entry);
+
     Entry get(byte[] key);
+
     void delete(byte[] key, Version version);
+
     Iterable<Entry> getAll();
 }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/PersistentStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/PersistentStore.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.facebook.airlift.log.Logger;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import org.iq80.leveldb.DB;
+import org.iq80.leveldb.Options;
+import org.iq80.leveldb.impl.Iq80DBFactory;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Map;
+
+import static com.google.common.base.Predicates.notNull;
+
+public class PersistentStore
+    implements LocalStore
+{
+    private static final Logger log = Logger.get(PersistentStore.class);
+    private final DB db;
+    private final ObjectMapper mapper = new ObjectMapper(new SmileFactory());
+
+    @Inject
+    public PersistentStore(PersistentStoreConfig config)
+            throws IOException
+    {
+        db = Iq80DBFactory.factory.open(config.getLocation(), new Options().createIfMissing(true));
+    }
+
+    @Override
+    public void put(Entry entry)
+    {
+        byte[] dbEntry;
+        try {
+            dbEntry = mapper.writeValueAsBytes(entry);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        db.put(entry.getKey(), dbEntry);
+    }
+
+    @Override
+    public Entry get(byte[] key)
+    {
+        try {
+            return mapper.readValue(db.get(key), Entry.class);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void delete(byte[] key, Version version)
+    {
+        db.delete(key);
+    }
+
+    @Override
+    public Iterable<Entry> getAll()
+    {
+        return Iterables.filter(Iterables.transform(db, new Function<Map.Entry<byte[], byte[]>, Entry>()
+        {
+            @Override
+            public Entry apply(Map.Entry<byte[], byte[]> dbEntry)
+            {
+                try {
+                    return mapper.readValue(dbEntry.getValue(), Entry.class);
+                }
+                catch (IOException e) {
+                    byte[] key = dbEntry.getKey();
+                    log.error(e, "Corrupt entry " + Arrays.toString(key));
+
+                    // delete the corrupt entry... if another node has a non-corrupt version it will be replicated
+                    db.delete(key);
+
+                    // null if filtered below
+                    return null;
+                }
+            }
+        }), notNull());
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/PersistentStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/PersistentStore.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import static com.google.common.base.Predicates.notNull;
 
 public class PersistentStore
-    implements LocalStore
+        implements LocalStore
 {
     private static final Logger log = Logger.get(PersistentStore.class);
     private final DB db;

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/PersistentStoreConfig.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/PersistentStoreConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+
+public class PersistentStoreConfig
+{
+    private File location = new File("db");
+
+    @NotNull
+    public File getLocation()
+    {
+        return location;
+    }
+
+    @Config("db.location")
+    public PersistentStoreConfig setLocation(File location)
+    {
+        this.location = location;
+        return this;
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/RealTimeSupplier.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/RealTimeSupplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.google.common.base.Supplier;
+import org.joda.time.DateTime;
+
+public class RealTimeSupplier
+        implements Supplier<DateTime>
+{
+    @Override
+    public DateTime get()
+    {
+        return new DateTime();
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/RealTimeSupplier.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/RealTimeSupplier.java
@@ -15,15 +15,15 @@
  */
 package com.facebook.airlift.discovery.store;
 
-import com.google.common.base.Supplier;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
 
 public class RealTimeSupplier
-        implements Supplier<DateTime>
+        implements Supplier<ZonedDateTime>
 {
     @Override
-    public DateTime get()
+    public ZonedDateTime get()
     {
-        return new DateTime();
+        return ZonedDateTime.now();
     }
 }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/RemoteStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/RemoteStore.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+public interface RemoteStore
+{
+    void put(Entry entry);
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ReplicatedStoreModule.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ReplicatedStoreModule.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.facebook.airlift.discovery.client.ServiceSelector;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.node.NodeInfo;
+import com.google.common.base.Supplier;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import org.joda.time.DateTime;
+import org.weakref.jmx.MBeanExporter;
+
+import javax.annotation.PreDestroy;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
+
+import java.lang.annotation.Annotation;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static com.google.inject.name.Names.named;
+import static org.weakref.jmx.ObjectNames.generatedNameOf;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+/**
+ * Expects a LocalStore to be bound elsewhere.
+ * Provides a DistributedStore with the specified annotation.
+ */
+public class ReplicatedStoreModule
+    implements Module
+{
+    private final String name;
+    private final Class<? extends Annotation> annotation;
+    private final Class<? extends LocalStore> localStoreClass;
+
+    public ReplicatedStoreModule(String name, Class<? extends Annotation> annotation, Class<? extends LocalStore> localStoreClass)
+    {
+        this.name = name;
+        this.annotation = annotation;
+        this.localStoreClass = localStoreClass;
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.requireExplicitBindings();
+        binder.disableCircularProxies();
+
+        // global
+        jaxrsBinder(binder).bind(StoreResource.class);
+        binder.bind(new TypeLiteral<Supplier<DateTime>>() {}).to(RealTimeSupplier.class).in(Scopes.SINGLETON);
+        binder.bind(ConflictResolver.class).in(Scopes.SINGLETON);
+
+        // per store
+        Key<HttpClient> httpClientKey = Key.get(HttpClient.class, annotation);
+        Key<LocalStore> localStoreKey = Key.get(LocalStore.class, annotation);
+        Key<StoreConfig> storeConfigKey = Key.get(StoreConfig.class, annotation);
+        Key<RemoteStore> remoteStoreKey = Key.get(RemoteStore.class, annotation);
+
+        configBinder(binder).bindConfig(StoreConfig.class, annotation, name);
+        httpClientBinder(binder).bindHttpClient(name, annotation);
+
+        binder.bind(DistributedStore.class).annotatedWith(annotation).toProvider(new DistributedStoreProvider(name, localStoreKey, storeConfigKey, remoteStoreKey)).in(Scopes.SINGLETON);
+        binder.bind(Replicator.class).annotatedWith(annotation).toProvider(new ReplicatorProvider(name, localStoreKey, httpClientKey, storeConfigKey)).in(Scopes.SINGLETON);
+        binder.bind(HttpRemoteStore.class).annotatedWith(annotation).toProvider(new RemoteHttpStoreProvider(name, httpClientKey, storeConfigKey)).in(Scopes.SINGLETON);
+        binder.bind(LocalStore.class).annotatedWith(annotation).to(localStoreClass).in(Scopes.SINGLETON);
+
+        binder.bind(RemoteStore.class).annotatedWith(annotation).to(Key.get(HttpRemoteStore.class, annotation));
+
+        newExporter(binder).export(DistributedStore.class).annotatedWith(annotation).as(generatedNameOf(DistributedStore.class, named(name)));
+        newExporter(binder).export(HttpRemoteStore.class).annotatedWith(annotation).as(generatedNameOf(HttpRemoteStore.class, named(name)));
+        newExporter(binder).export(Replicator.class).annotatedWith(annotation).as(generatedNameOf(Replicator.class, named(name)));
+
+        newMapBinder(binder, String.class, LocalStore.class)
+            .addBinding(name)
+            .to(localStoreKey);
+
+        newMapBinder(binder, String.class, StoreConfig.class)
+                .addBinding(name)
+                .to(storeConfigKey);
+    }
+
+    @ThreadSafe
+    private static class ReplicatorProvider
+        implements Provider<Replicator>
+    {
+        private final String name;
+        private final Key<? extends LocalStore> localStoreKey;
+        private final Key<? extends HttpClient> httpClientKey;
+        private final Key<StoreConfig> storeConfigKey;
+
+        @GuardedBy("this")
+        private Injector injector;
+
+        @GuardedBy("this")
+        private NodeInfo nodeInfo;
+
+        @GuardedBy("this")
+        private ServiceSelector serviceSelector;
+
+        @GuardedBy("this")
+        private Replicator replicator;
+
+        private ReplicatorProvider(String name, Key<? extends LocalStore> localStoreKey, Key<? extends HttpClient> httpClientKey, Key<StoreConfig> storeConfigKey)
+        {
+            this.name = name;
+            this.localStoreKey = localStoreKey;
+            this.httpClientKey = httpClientKey;
+            this.storeConfigKey = storeConfigKey;
+        }
+
+        @Override
+        public synchronized Replicator get()
+        {
+            if (replicator == null) {
+                LocalStore localStore = injector.getInstance(localStoreKey);
+                HttpClient httpClient = injector.getInstance(httpClientKey);
+                StoreConfig storeConfig = injector.getInstance(storeConfigKey);
+
+                replicator = new Replicator(name, nodeInfo, serviceSelector, httpClient, localStore, storeConfig);
+                replicator.start();
+            }
+
+            return replicator;
+        }
+
+        @PreDestroy
+        public synchronized void shutdown()
+        {
+            if (replicator != null) {
+                replicator.shutdown();
+            }
+        }
+
+        @Inject
+        public synchronized void setInjector(Injector injector)
+        {
+            this.injector = injector;
+        }
+
+        @Inject
+        public synchronized void setNodeInfo(NodeInfo nodeInfo)
+        {
+            this.nodeInfo = nodeInfo;
+        }
+
+        @Inject
+        public synchronized void setServiceSelector(ServiceSelector serviceSelector)
+        {
+            this.serviceSelector = serviceSelector;
+        }
+    }
+
+    @ThreadSafe
+    private static class RemoteHttpStoreProvider
+            implements Provider<HttpRemoteStore>
+    {
+        @GuardedBy("this")
+        private HttpRemoteStore remoteStore;
+
+        @GuardedBy("this")
+        private Injector injector;
+
+        @GuardedBy("this")
+        private NodeInfo nodeInfo;
+
+        @GuardedBy("this")
+        private ServiceSelector serviceSelector;
+
+        @GuardedBy("this")
+        private MBeanExporter mbeanExporter;
+
+        private final String name;
+        private final Key<? extends HttpClient> httpClientKey;
+        private final Key<StoreConfig> storeConfigKey;
+
+
+        @Inject
+        private RemoteHttpStoreProvider(String name, Key<? extends HttpClient> httpClientKey, Key<StoreConfig> storeConfigKey)
+        {
+            this.name = name;
+            this.httpClientKey = httpClientKey;
+            this.storeConfigKey = storeConfigKey;
+        }
+
+        public synchronized HttpRemoteStore get()
+        {
+            if (remoteStore == null) {
+                HttpClient httpClient = injector.getInstance(httpClientKey);
+                StoreConfig storeConfig = injector.getInstance(storeConfigKey);
+
+                remoteStore = new HttpRemoteStore(name, nodeInfo, serviceSelector, storeConfig, httpClient, mbeanExporter);
+                remoteStore.start();
+            }
+
+            return remoteStore;
+        }
+
+        @PreDestroy
+        public synchronized void shutdown()
+        {
+            if (remoteStore != null) {
+                remoteStore.shutdown();
+            }
+        }
+
+        @Inject
+        public synchronized void setInjector(Injector injector)
+        {
+            this.injector = injector;
+        }
+
+        @Inject
+        public synchronized void setNodeInfo(NodeInfo nodeInfo)
+        {
+            this.nodeInfo = nodeInfo;
+        }
+
+        @Inject
+        public synchronized void setServiceSelector(ServiceSelector serviceSelector)
+        {
+            this.serviceSelector = serviceSelector;
+        }
+
+        @Inject
+        public synchronized void setMbeanExporter(MBeanExporter mbeanExporter)
+        {
+            this.mbeanExporter = mbeanExporter;
+        }
+    }
+
+    private static class DistributedStoreProvider
+            implements Provider<DistributedStore>
+    {
+        private final String name;
+        private final Key<? extends LocalStore> localStoreKey;
+        private final Key<StoreConfig> storeConfigKey;
+        private final Key<? extends RemoteStore> remoteStoreKey;
+
+        private Injector injector;
+        private Supplier<DateTime> timeSupplier;
+        private DistributedStore store;
+
+        public DistributedStoreProvider(String name,
+                Key<? extends LocalStore> localStoreKey,
+                Key<StoreConfig> storeConfigKey,
+                Key<? extends RemoteStore> remoteStoreKey)
+        {
+            this.name = name;
+            this.localStoreKey = localStoreKey;
+            this.storeConfigKey = storeConfigKey;
+            this.remoteStoreKey = remoteStoreKey;
+        }
+
+        @Override
+        public synchronized DistributedStore get()
+        {
+            if (store == null) {
+                LocalStore localStore = injector.getInstance(localStoreKey);
+                StoreConfig storeConfig = injector.getInstance(storeConfigKey);
+                RemoteStore remoteStore = injector.getInstance(remoteStoreKey);
+
+                store = new DistributedStore(name, localStore, remoteStore, storeConfig, timeSupplier);
+                store.start();
+            }
+
+            return store;
+        }
+
+        @PreDestroy
+        public synchronized void shutdown()
+        {
+            if (store != null) {
+                store.shutdown();
+            }
+        }
+
+        @Inject
+        public synchronized void setInjector(Injector injector)
+        {
+            this.injector = injector;
+        }
+
+        @Inject
+        public synchronized void setTimeSupplier(Supplier<DateTime> timeSupplier)
+        {
+            this.timeSupplier = timeSupplier;
+        }
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ReplicatedStoreModule.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ReplicatedStoreModule.java
@@ -49,7 +49,7 @@ import static org.weakref.jmx.guice.ExportBinder.newExporter;
  * Provides a DistributedStore with the specified annotation.
  */
 public class ReplicatedStoreModule
-    implements Module
+        implements Module
 {
     private final String name;
     private final Class<? extends Annotation> annotation;
@@ -94,8 +94,8 @@ public class ReplicatedStoreModule
         newExporter(binder).export(Replicator.class).annotatedWith(annotation).as(generatedNameOf(Replicator.class, named(name)));
 
         newMapBinder(binder, String.class, LocalStore.class)
-            .addBinding(name)
-            .to(localStoreKey);
+                .addBinding(name)
+                .to(localStoreKey);
 
         newMapBinder(binder, String.class, StoreConfig.class)
                 .addBinding(name)
@@ -104,7 +104,7 @@ public class ReplicatedStoreModule
 
     @ThreadSafe
     private static class ReplicatorProvider
-        implements Provider<Replicator>
+            implements Provider<Replicator>
     {
         private final String name;
         private final Key<? extends LocalStore> localStoreKey;
@@ -195,7 +195,6 @@ public class ReplicatedStoreModule
         private final String name;
         private final Key<? extends HttpClient> httpClientKey;
         private final Key<StoreConfig> storeConfigKey;
-
 
         @Inject
         private RemoteHttpStoreProvider(String name, Key<? extends HttpClient> httpClientKey, Key<StoreConfig> storeConfigKey)

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ReplicatedStoreModule.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ReplicatedStoreModule.java
@@ -18,23 +18,23 @@ package com.facebook.airlift.discovery.store;
 import com.facebook.airlift.discovery.client.ServiceSelector;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.node.NodeInfo;
-import com.google.common.base.Supplier;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
-import org.joda.time.DateTime;
 import org.weakref.jmx.MBeanExporter;
 
 import javax.annotation.PreDestroy;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 import java.lang.annotation.Annotation;
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
@@ -70,7 +70,7 @@ public class ReplicatedStoreModule
 
         // global
         jaxrsBinder(binder).bind(StoreResource.class);
-        binder.bind(new TypeLiteral<Supplier<DateTime>>() {}).to(RealTimeSupplier.class).in(Scopes.SINGLETON);
+        binder.bind(new TypeLiteral<Supplier<ZonedDateTime>>() {}).to(RealTimeSupplier.class).in(Scopes.SINGLETON);
         binder.bind(ConflictResolver.class).in(Scopes.SINGLETON);
 
         // per store
@@ -104,7 +104,7 @@ public class ReplicatedStoreModule
 
     @ThreadSafe
     private static class ReplicatorProvider
-            implements Provider<Replicator>
+            implements javax.inject.Provider<Replicator>
     {
         private final String name;
         private final Key<? extends LocalStore> localStoreKey;
@@ -259,7 +259,7 @@ public class ReplicatedStoreModule
         private final Key<? extends RemoteStore> remoteStoreKey;
 
         private Injector injector;
-        private Supplier<DateTime> timeSupplier;
+        private Supplier<ZonedDateTime> timeSupplier;
         private DistributedStore store;
 
         public DistributedStoreProvider(String name,
@@ -303,7 +303,7 @@ public class ReplicatedStoreModule
         }
 
         @Inject
-        public synchronized void setTimeSupplier(Supplier<DateTime> timeSupplier)
+        public synchronized void setTimeSupplier(Supplier<ZonedDateTime> timeSupplier)
         {
             this.timeSupplier = timeSupplier;
         }

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Replicator.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Replicator.java
@@ -23,10 +23,10 @@ import com.facebook.airlift.http.client.Response;
 import com.facebook.airlift.http.client.ResponseHandler;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.node.NodeInfo;
+import com.facebook.airlift.units.Duration;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
-import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 
 import javax.annotation.PostConstruct;

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Replicator.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Replicator.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.facebook.airlift.discovery.client.ServiceDescriptor;
+import com.facebook.airlift.discovery.client.ServiceSelector;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.Response;
+import com.facebook.airlift.http.client.ResponseHandler;
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.node.NodeInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import io.airlift.units.Duration;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.io.EOFException;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+public class Replicator
+{
+    private final static Logger log = Logger.get(Replicator.class);
+
+    private final String name;
+    private final NodeInfo node;
+    private final ServiceSelector selector;
+    private final HttpClient httpClient;
+    private final LocalStore localStore;
+    private final Duration replicationInterval;
+
+    private ScheduledFuture<?> future;
+    private ScheduledExecutorService executor;
+
+    private final ObjectMapper mapper = new ObjectMapper(new SmileFactory());
+    private final AtomicLong lastReplicationTimestamp = new AtomicLong();
+
+    @Inject
+    public Replicator(String name,
+            NodeInfo node,
+            ServiceSelector selector,
+            HttpClient httpClient,
+            LocalStore localStore,
+            StoreConfig config)
+    {
+        this.name = name;
+        this.node = node;
+        this.selector = selector;
+        this.httpClient = httpClient;
+        this.localStore = localStore;
+
+        this.replicationInterval = config.getReplicationInterval();
+
+    }
+
+    @PostConstruct
+    public synchronized void start()
+    {
+        if (future == null) {
+            executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("replicator-" + name));
+
+            future = executor.scheduleAtFixedRate(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    try {
+                        synchronize();
+                    }
+                    catch (Throwable t) {
+                        log.warn(t, "Error replicating state");
+                    }
+                }
+            }, 0, replicationInterval.toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        // TODO: need fail-safe recurrent scheduler with variable delay
+    }
+
+    @PreDestroy
+    public synchronized void shutdown()
+    {
+        if (future != null) {
+            future.cancel(true);
+            executor.shutdownNow();
+
+            executor = null;
+            future = null;
+        }
+    }
+
+    @Managed
+    public long getLastReplicationTimestamp()
+    {
+        return lastReplicationTimestamp.get();
+    }
+
+    private void synchronize()
+    {
+        for (ServiceDescriptor descriptor : selector.selectAllServices()) {
+            if (descriptor.getNodeId().equals(node.getNodeId())) {
+                // don't write to ourselves
+                continue;
+            }
+
+            String uri = descriptor.getProperties().get("https") != null ? descriptor.getProperties().get("https") : descriptor.getProperties().get("http");
+            if (uri == null) {
+                log.error("service descriptor for node %s is missing http uri", descriptor.getNodeId());
+                continue;
+            }
+
+            // TODO: build URI from resource class
+            Request request = Request.Builder.prepareGet()
+                    .setUri(URI.create(uri + "/v1/store/" + name))
+                    .build();
+
+            try {
+                httpClient.execute(request, new ResponseHandler<Void, Exception>()
+                {
+                    @Override
+                    public Void handleException(Request request, Exception exception)
+                            throws Exception
+                    {
+                        throw exception;
+                    }
+
+                    @Override
+                    public Void handle(Request request, Response response)
+                            throws Exception
+                    {
+                        // TODO: read server date (to use to calibrate entry dates)
+
+
+                        if (response.getStatusCode() == 200) {
+                            try {
+                                List<Entry> entries = mapper.readValue(response.getInputStream(), new TypeReference<List<Entry>>() {});
+                                for (Entry entry : entries) {
+                                    localStore.put(entry);
+                                }
+                            }
+                            catch (EOFException e) {
+                                // ignore
+                            }
+                        }
+
+                        return null;
+                    }
+                });
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+        }
+
+        lastReplicationTimestamp.set(System.currentTimeMillis());
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Replicator.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Replicator.java
@@ -46,7 +46,7 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
 public class Replicator
 {
-    private final static Logger log = Logger.get(Replicator.class);
+    private static final Logger log = Logger.get(Replicator.class);
 
     private final String name;
     private final NodeInfo node;
@@ -76,7 +76,6 @@ public class Replicator
         this.localStore = localStore;
 
         this.replicationInterval = config.getReplicationInterval();
-
     }
 
     @PostConstruct
@@ -155,7 +154,6 @@ public class Replicator
                             throws Exception
                     {
                         // TODO: read server date (to use to calibrate entry dates)
-
 
                         if (response.getStatusCode() == 200) {
                             try {

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreConfig.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreConfig.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class StoreConfig
+{
+    private Duration tombstoneMaxAge = new Duration(1, TimeUnit.DAYS);
+    private Duration garbageCollectionInterval = new Duration(1, TimeUnit.HOURS);
+    private int maxBatchSize = 1000;
+    private int queueSize = 1000;
+    private Duration remoteUpdateInterval = new Duration(5, TimeUnit.SECONDS);
+    private Duration replicationInterval = new Duration(1, TimeUnit.MINUTES);
+
+    @NotNull
+    public Duration getTombstoneMaxAge()
+    {
+        return tombstoneMaxAge;
+    }
+
+    @Config("store.tombstone-max-age")
+    public StoreConfig setTombstoneMaxAge(Duration age)
+    {
+        this.tombstoneMaxAge = age;
+        return this;
+    }
+
+    @NotNull
+    public Duration getGarbageCollectionInterval()
+    {
+        return garbageCollectionInterval;
+    }
+
+    @Config("store.gc-interval")
+    public StoreConfig setGarbageCollectionInterval(Duration interval)
+    {
+        this.garbageCollectionInterval = interval;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxBatchSize()
+    {
+        return maxBatchSize;
+    }
+
+    @Config("store.remote.max-batch-size")
+    public StoreConfig setMaxBatchSize(int maxBatchSize)
+    {
+        this.maxBatchSize = maxBatchSize;
+        return this;
+    }
+
+    @Min(1)
+    public int getQueueSize()
+    {
+        return queueSize;
+    }
+
+    @Config("store.remote.queue-size")
+    public StoreConfig setQueueSize(int queueSize)
+    {
+        this.queueSize = queueSize;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    @NotNull
+    public Duration getRemoteUpdateInterval()
+    {
+        return remoteUpdateInterval;
+    }
+
+    @Config("store.remote.update-interval")
+    public StoreConfig setRemoteUpdateInterval(Duration remoteUpdateInterval)
+    {
+        this.remoteUpdateInterval = remoteUpdateInterval;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getReplicationInterval()
+    {
+        return replicationInterval;
+    }
+
+    @Config("store.remote.replication-interval")
+    public StoreConfig setReplicationInterval(Duration replicationInterval)
+    {
+        this.replicationInterval = replicationInterval;
+        return this;
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreConfig.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreConfig.java
@@ -16,8 +16,8 @@
 package com.facebook.airlift.discovery.store;
 
 import com.facebook.airlift.configuration.Config;
-import io.airlift.units.Duration;
-import io.airlift.units.MinDuration;
+import com.facebook.airlift.units.Duration;
+import com.facebook.airlift.units.MinDuration;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreResource.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.airlift.units.Duration;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import java.util.List;
+import java.util.Map;
+
+@Path("/v1/store/{store}")
+public class StoreResource
+{
+    private final Map<String, LocalStore> localStores;
+    private final Map<String, Duration> tombstoneMaxAges;
+
+    @Inject
+    public StoreResource(Map<String, LocalStore> localStores, Map<String, StoreConfig> configs)
+    {
+        this.localStores = ImmutableMap.copyOf(localStores);
+        this.tombstoneMaxAges = ImmutableMap.copyOf(Maps.transformValues(configs, new Function<StoreConfig, Duration>()
+        {
+            @Override
+            public Duration apply(@Nullable StoreConfig config)
+            {
+                return config.getTombstoneMaxAge();
+            }
+        }));
+    }
+
+    @PUT
+    @Path("{key}")
+    public void put(@PathParam("store") String storeName, @PathParam("key") String key, byte[] value)
+    {
+        LocalStore store = localStores.get(storeName);
+
+        Entry entry = new Entry(key.getBytes(Charsets.UTF_8), value, new Version(System.currentTimeMillis()), System.currentTimeMillis(), null); // TODO: version
+        store.put(entry);
+    }
+    
+    @POST
+    @Consumes({"application/x-jackson-smile", "application/json"})
+    public Response setMultipleEntries(@PathParam("store") String storeName, List<Entry> entries)
+    {
+        LocalStore store = localStores.get(storeName);
+        Duration tombstoneMaxAge = tombstoneMaxAges.get(storeName);
+        if (store == null || tombstoneMaxAge == null) {
+            return Response.status(Status.NOT_FOUND).build();
+        }
+
+        for (Entry entry : entries) {
+            if (!isExpired(tombstoneMaxAge, entry)) {
+                store.put(entry);
+            }
+        }
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Produces({"application/x-jackson-smile", "application/json"})
+    public Response getAll(@PathParam("store") String storeName)
+    {
+        LocalStore store = localStores.get(storeName);
+        if (store == null) {
+            return Response.status(Status.NOT_FOUND).build();
+        }
+        return Response.ok(store.getAll()).build();
+    }
+
+    private boolean isExpired(Duration tombstoneMaxAge, Entry entry)
+    {
+        long ageInMs = System.currentTimeMillis() - entry.getTimestamp();
+
+        return entry.getValue() == null && ageInMs > tombstoneMaxAge.toMillis() ||
+                entry.getMaxAgeInMs() != null && ageInMs > entry.getMaxAgeInMs();
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreResource.java
@@ -15,13 +15,9 @@
  */
 package com.facebook.airlift.discovery.store;
 
-import com.google.common.base.Charsets;
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import io.airlift.units.Duration;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -33,8 +29,11 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 @Path("/v1/store/{store}")
 public class StoreResource
@@ -46,14 +45,9 @@ public class StoreResource
     public StoreResource(Map<String, LocalStore> localStores, Map<String, StoreConfig> configs)
     {
         this.localStores = ImmutableMap.copyOf(localStores);
-        this.tombstoneMaxAges = ImmutableMap.copyOf(Maps.transformValues(configs, new Function<StoreConfig, Duration>()
-        {
-            @Override
-            public Duration apply(@Nullable StoreConfig config)
-            {
-                return config.getTombstoneMaxAge();
-            }
-        }));
+        this.tombstoneMaxAges = configs.entrySet().stream().collect(toImmutableMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().getTombstoneMaxAge()));
     }
 
     @PUT
@@ -62,7 +56,7 @@ public class StoreResource
     {
         LocalStore store = localStores.get(storeName);
 
-        Entry entry = new Entry(key.getBytes(Charsets.UTF_8), value, new Version(System.currentTimeMillis()), System.currentTimeMillis(), null); // TODO: version
+        Entry entry = new Entry(key.getBytes(StandardCharsets.UTF_8), value, new Version(System.currentTimeMillis()), System.currentTimeMillis(), null); // TODO: version
         store.put(entry);
     }
 

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreResource.java
@@ -15,8 +15,8 @@
  */
 package com.facebook.airlift.discovery.store;
 
+import com.facebook.airlift.units.Duration;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.units.Duration;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreResource.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/StoreResource.java
@@ -65,7 +65,7 @@ public class StoreResource
         Entry entry = new Entry(key.getBytes(Charsets.UTF_8), value, new Version(System.currentTimeMillis()), System.currentTimeMillis(), null); // TODO: version
         store.put(entry);
     }
-    
+
     @POST
     @Consumes({"application/x-jackson-smile", "application/json"})
     public Response setMultipleEntries(@PathParam("store") String storeName, List<Entry> entries)

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Version.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Version.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.primitives.Longs;
+
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public class Version
+{
+    private final long sequence;
+
+    @JsonCreator
+    public Version(@JsonProperty("sequence") long sequence)
+    {
+        this.sequence = sequence;
+    }
+
+    @JsonProperty
+    public long getSequence()
+    {
+        return sequence;
+    }
+
+    public Occurs compare(Version other)
+    {
+        int comparison = Longs.compare(sequence, other.sequence);
+
+        if (comparison < 0) {
+            return Occurs.BEFORE;
+        }
+        else if (comparison > 0) {
+            return Occurs.AFTER;
+        }
+
+        return Occurs.SAME;
+    }
+    
+    public enum Occurs
+    {
+        BEFORE, SAME, CONCURRENT, AFTER
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Version version = (Version) o;
+
+        if (sequence != version.sequence) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (int) (sequence ^ (sequence >>> 32));
+    }
+}

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Version.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Version.java
@@ -17,7 +17,6 @@ package com.facebook.airlift.discovery.store;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.primitives.Longs;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -40,7 +39,7 @@ public class Version
 
     public Occurs compare(Version other)
     {
-        int comparison = Longs.compare(sequence, other.sequence);
+        int comparison = Long.compare(sequence, other.sequence);
 
         if (comparison < 0) {
             return Occurs.BEFORE;

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Version.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/Version.java
@@ -51,7 +51,7 @@ public class Version
 
         return Occurs.SAME;
     }
-    
+
     public enum Occurs
     {
         BEFORE, SAME, CONCURRENT, AFTER

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryDynamicStore.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+
+import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.airlift.discovery.server.DynamicServiceAnnouncement.toServiceWith;
+import static com.facebook.airlift.discovery.server.Service.matchesPool;
+import static com.facebook.airlift.discovery.server.Service.matchesType;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.collect.Collections2.transform;
+import static com.google.common.collect.Iterables.filter;
+
+@ThreadSafe
+public class InMemoryDynamicStore
+        implements DynamicStore
+{
+    private final Map<Id<Node>, Entry> descriptors = Maps.newHashMap();
+    private final Duration maxAge;
+    private final Supplier<DateTime> currentTime;
+
+    @Inject
+    public InMemoryDynamicStore(DiscoveryConfig config, Supplier<DateTime> timeSource)
+    {
+        this.currentTime = timeSource;
+        this.maxAge = config.getMaxAge();
+    }
+
+    @Override
+    public synchronized void put(Id<Node> nodeId, DynamicAnnouncement announcement)
+    {
+        Preconditions.checkNotNull(nodeId, "nodeId is null");
+        Preconditions.checkNotNull(announcement, "announcement is null");
+
+        Set<Service> services = ImmutableSet.copyOf(transform(announcement.getServiceAnnouncements(), toServiceWith(nodeId, announcement.getLocation(), announcement.getPool())));
+
+        DateTime expiration = currentTime.get().plusMillis((int) maxAge.toMillis());
+        descriptors.put(nodeId, new Entry(expiration, services));
+    }
+
+    @Override
+    public synchronized void delete(Id<Node> nodeId)
+    {
+        Preconditions.checkNotNull(nodeId, "nodeId is null");
+
+        descriptors.remove(nodeId);
+    }
+
+    @Override
+    public synchronized Set<Service> getAll()
+    {
+        removeExpired();
+
+        ImmutableSet.Builder<Service> builder = ImmutableSet.builder();
+        for (Entry entry : descriptors.values()) {
+            builder.addAll(entry.getServices());
+        }
+        return builder.build();
+    }
+
+    @Override
+    public synchronized Set<Service> get(String type)
+    {
+        Preconditions.checkNotNull(type, "type is null");
+
+        return ImmutableSet.copyOf(filter(getAll(), matchesType(type)));
+    }
+
+    @Override
+    public synchronized Set<Service> get(String type, String pool)
+    {
+        Preconditions.checkNotNull(type, "type is null");
+        Preconditions.checkNotNull(pool, "pool is null");
+
+        return ImmutableSet.copyOf(filter(getAll(), and(matchesType(type), matchesPool(pool))));
+    }
+
+    private synchronized void removeExpired()
+    {
+        Iterator<Entry> iterator = descriptors.values().iterator();
+
+        DateTime now = currentTime.get();
+        while (iterator.hasNext()) {
+            Entry entry = iterator.next();
+
+            if (now.isAfter(entry.getExpiration())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private static class Entry
+    {
+        private final Set<Service> services;
+        private final DateTime expiration;
+
+        public Entry(DateTime expiration, Set<Service> services)
+        {
+            this.expiration = expiration;
+            this.services = ImmutableSet.copyOf(services);
+        }
+
+        public DateTime getExpiration()
+        {
+            return expiration;
+        }
+
+        public Set<Service> getServices()
+        {
+            return services;
+        }
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryDynamicStore.java
@@ -15,8 +15,8 @@
  */
 package com.facebook.airlift.discovery.server;
 
+import com.facebook.airlift.units.Duration;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.units.Duration;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryStaticStore.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.airlift.discovery.server.Service.matchesPool;
+import static com.facebook.airlift.discovery.server.Service.matchesType;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.collect.Iterables.filter;
+
+public class InMemoryStaticStore
+    implements StaticStore
+{
+    private final Map<Id<Service>, Service> services = Maps.newHashMap();
+
+    @Override
+    public synchronized void put(Service service)
+    {
+        Preconditions.checkNotNull(service, "service is null");
+        Preconditions.checkArgument(service.getNodeId() == null, "service.nodeId should be null");
+
+        services.put(service.getId(), service);
+    }
+
+    @Override
+    public synchronized void delete(Id<Service> id)
+    {
+        services.remove(id);
+    }
+
+    @Override
+    public synchronized Set<Service> getAll()
+    {
+        return ImmutableSet.copyOf(services.values());
+    }
+
+    @Override
+    public synchronized Set<Service> get(String type)
+    {
+        return ImmutableSet.copyOf(filter(getAll(), matchesType(type)));
+    }
+
+    @Override
+    public synchronized Set<Service> get(String type, String pool)
+    {
+        return ImmutableSet.copyOf(filter(getAll(), and(matchesType(type), matchesPool(pool))));
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryStaticStore.java
@@ -17,25 +17,25 @@ package com.facebook.airlift.discovery.server;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.airlift.discovery.server.Service.matchesPool;
 import static com.facebook.airlift.discovery.server.Service.matchesType;
-import static com.google.common.base.Predicates.and;
-import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
 
 public class InMemoryStaticStore
         implements StaticStore
 {
-    private final Map<Id<Service>, Service> services = Maps.newHashMap();
+    private final Map<Id<Service>, Service> services = new HashMap<>();
 
     @Override
     public synchronized void put(Service service)
     {
-        Preconditions.checkNotNull(service, "service is null");
+        requireNonNull(service, "service is null");
         Preconditions.checkArgument(service.getNodeId() == null, "service.nodeId should be null");
 
         services.put(service.getId(), service);
@@ -56,12 +56,14 @@ public class InMemoryStaticStore
     @Override
     public synchronized Set<Service> get(String type)
     {
-        return ImmutableSet.copyOf(filter(getAll(), matchesType(type)));
+        return getAll().stream().filter(service -> matchesType(type).test(service)).collect(toImmutableSet());
     }
 
     @Override
     public synchronized Set<Service> get(String type, String pool)
     {
-        return ImmutableSet.copyOf(filter(getAll(), and(matchesType(type), matchesPool(pool))));
+        return getAll().stream()
+                .filter(service -> matchesType(type).test(service) && matchesPool(pool).test(service))
+                .collect(toImmutableSet());
     }
 }

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/InMemoryStaticStore.java
@@ -28,7 +28,7 @@ import static com.google.common.base.Predicates.and;
 import static com.google.common.collect.Iterables.filter;
 
 public class InMemoryStaticStore
-    implements StaticStore
+        implements StaticStore
 {
     private final Map<Id<Service>, Service> services = Maps.newHashMap();
 

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryConfig.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.testing.ValidationAssertions.assertFailsValidation;
+
+public class TestDiscoveryConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(DiscoveryConfig.class)
+                .setMaxAge(new Duration(30, TimeUnit.SECONDS))
+                .setStoreCacheTtl(new Duration(1, TimeUnit.SECONDS)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("discovery.max-age", "1m")
+                .put("discovery.store-cache-ttl", "13s")
+                .build();
+
+        DiscoveryConfig expected = new DiscoveryConfig()
+                .setMaxAge(new Duration(1, TimeUnit.MINUTES))
+                .setStoreCacheTtl(new Duration(13, TimeUnit.SECONDS));
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+
+
+    @Test
+    public void testValidatesNotNullDuration()
+    {
+        DiscoveryConfig config = new DiscoveryConfig().setMaxAge(null);
+
+        assertFailsValidation(config, "maxAge", "may not be null", NotNull.class);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryConfig.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryConfig.java
@@ -52,7 +52,6 @@ public class TestDiscoveryConfig
         ConfigAssertions.assertFullMapping(properties, expected);
     }
 
-
     @Test
     public void testValidatesNotNullDuration()
     {

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryConfig.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryConfig.java
@@ -16,8 +16,8 @@
 package com.facebook.airlift.discovery.server;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.airlift.units.Duration;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import javax.validation.constraints.NotNull;

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryServer.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryServer.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.discovery.client.DiscoveryAnnouncementClient;
+import com.facebook.airlift.discovery.client.DiscoveryModule;
+import com.facebook.airlift.discovery.client.ServiceAnnouncement;
+import com.facebook.airlift.discovery.client.ServiceDescriptor;
+import com.facebook.airlift.discovery.client.ServiceSelector;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.airlift.http.server.testing.TestingHttpServer;
+import com.facebook.airlift.http.server.testing.TestingHttpServerModule;
+import com.facebook.airlift.jaxrs.JaxrsModule;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.airlift.node.NodeInfo;
+import com.facebook.airlift.node.testing.TestingNodeModule;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import org.iq80.leveldb.util.FileUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.weakref.jmx.guice.MBeanModule;
+import org.weakref.jmx.testing.TestingMBeanServer;
+
+import javax.management.MBeanServer;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
+import static com.facebook.airlift.discovery.client.ServiceTypes.serviceType;
+import static com.facebook.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import static com.facebook.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static com.facebook.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static com.facebook.airlift.http.client.Request.Builder.prepareDelete;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.StatusResponseHandler.StatusResponse;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
+import static javax.ws.rs.core.Response.Status;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestDiscoveryServer
+{
+    private TestingHttpServer server;
+    private File tempDir;
+
+    @BeforeMethod
+    public void setup()
+            throws Exception
+    {
+        tempDir = Files.createTempDir();
+
+        // start server
+        Map<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("static.db.location", tempDir.getAbsolutePath())
+                .put("discovery.store-cache-ttl", "0s")
+                .build();
+
+        Bootstrap bootstrap = new Bootstrap(
+                new MBeanModule(),
+                new TestingNodeModule("testing"),
+                new TestingHttpServerModule(),
+                new JsonModule(),
+                new JaxrsModule(true),
+                new DiscoveryServerModule(),
+                new DiscoveryModule(),
+                new Module()
+                {
+                    public void configure(Binder binder)
+                    {
+                        // TODO: use testing mbean server
+                        binder.bind(MBeanServer.class).toInstance(new TestingMBeanServer());
+                    }
+                });
+
+        Injector serverInjector = bootstrap
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(serverProperties)
+                .initialize();
+
+        server = serverInjector.getInstance(TestingHttpServer.class);
+        server.start();
+    }
+
+    @AfterMethod
+    public void teardown()
+            throws Exception
+    {
+        server.stop();
+        FileUtils.deleteRecursively(tempDir);
+    }
+
+    @Test
+    public void testDynamicAnnouncement()
+            throws Exception
+    {
+        // publish announcement
+        Map<String, String> announcerProperties = ImmutableMap.<String, String>builder()
+                .put("discovery.uri", server.getBaseUrl().toString())
+                .build();
+
+        Bootstrap bootstrap = new Bootstrap(
+                new TestingNodeModule("testing", "red"),
+                new JsonModule(),
+                new DiscoveryModule());
+
+        Injector announcerInjector = bootstrap
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(announcerProperties)
+                .initialize();
+
+        ServiceAnnouncement announcement = ServiceAnnouncement.serviceAnnouncement("apple")
+                .addProperties(ImmutableMap.of("key", "value"))
+                .build();
+
+        DiscoveryAnnouncementClient client = announcerInjector.getInstance(DiscoveryAnnouncementClient.class);
+        client.announce(ImmutableSet.of(announcement)).get();
+
+        NodeInfo announcerNodeInfo = announcerInjector.getInstance(NodeInfo.class);
+
+        List<ServiceDescriptor> services = selectorFor("apple", "red").selectAllServices();
+        assertEquals(services.size(), 1);
+
+        ServiceDescriptor service = services.get(0);
+        assertNotNull(service.getId());
+        assertEquals(service.getNodeId(), announcerNodeInfo.getNodeId());
+        assertEquals(service.getLocation(), announcerNodeInfo.getLocation());
+        assertEquals(service.getPool(), announcerNodeInfo.getPool());
+        assertEquals(service.getProperties(), announcement.getProperties());
+
+
+        // ensure that service is no longer visible
+        client.unannounce().get();
+
+        assertTrue(selectorFor("apple", "red").selectAllServices().isEmpty());
+    }
+
+
+    @Test
+    public void testStaticAnnouncement()
+            throws Exception
+    {
+        // create static announcement
+        Map<String, Object> announcement = ImmutableMap.<String, Object>builder()
+                .put("environment", "testing")
+                .put("type", "apple")
+                .put("pool", "red")
+                .put("location", "/a/b/c")
+                .put("properties", ImmutableMap.of("http", "http://host"))
+                .build();
+
+        HttpClient client = new JettyHttpClient();
+
+        Request request = preparePost()
+                .setUri(uriFor("/v1/announcement/static"))
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .setBodyGenerator(jsonBodyGenerator(jsonCodec(Object.class), announcement))
+                .build();
+        JsonResponse<Map<String, Object>> createResponse = client.execute(request, createFullJsonResponseHandler(mapJsonCodec(String.class, Object.class)));
+
+        assertEquals(createResponse.getStatusCode(), Status.CREATED.getStatusCode());
+        String id = createResponse.getValue().get("id").toString();
+
+        List<ServiceDescriptor> services = selectorFor("apple", "red").selectAllServices();
+        assertEquals(services.size(), 1);
+
+        ServiceDescriptor service = services.get(0);
+        assertEquals(service.getId().toString(), id);
+        assertNull(service.getNodeId());
+        assertEquals(service.getLocation(), announcement.get("location"));
+        assertEquals(service.getPool(), announcement.get("pool"));
+        assertEquals(service.getProperties(), announcement.get("properties"));
+
+        // remove announcement
+        request = prepareDelete().setUri(uriFor("/v1/announcement/static/" + id)).build();
+        StatusResponse deleteResponse = client.execute(request, createStatusResponseHandler());
+
+        assertEquals(deleteResponse.getStatusCode(), Status.NO_CONTENT.getStatusCode());
+
+        // ensure announcement is gone
+        assertTrue(selectorFor("apple", "red").selectAllServices().isEmpty());
+    }
+
+    private ServiceSelector selectorFor(String type, String pool)
+            throws Exception
+    {
+        Map<String, String> clientProperties = ImmutableMap.<String, String>builder()
+            .put("discovery.uri", server.getBaseUrl().toString())
+            .put("discovery.apple.pool", "red")
+            .build();
+
+        Bootstrap bootstrap = new Bootstrap(
+                new TestingNodeModule("testing"),
+                new JsonModule(),
+                new DiscoveryModule(),
+                new Module() {
+                    @Override
+                    public void configure(Binder binder)
+                    {
+                        discoveryBinder(binder).bindSelector("apple");
+                    }
+                });
+
+        Injector clientInjector = bootstrap
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(clientProperties)
+                .initialize();
+
+        return clientInjector.getInstance(Key.get(ServiceSelector.class, serviceType("apple")));
+    }
+
+    private URI uriFor(String path)
+    {
+        return server.getBaseUrl().resolve(path);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryServer.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDiscoveryServer.java
@@ -159,13 +159,11 @@ public class TestDiscoveryServer
         assertEquals(service.getPool(), announcerNodeInfo.getPool());
         assertEquals(service.getProperties(), announcement.getProperties());
 
-
         // ensure that service is no longer visible
         client.unannounce().get();
 
         assertTrue(selectorFor("apple", "red").selectAllServices().isEmpty());
     }
-
 
     @Test
     public void testStaticAnnouncement()
@@ -216,15 +214,16 @@ public class TestDiscoveryServer
             throws Exception
     {
         Map<String, String> clientProperties = ImmutableMap.<String, String>builder()
-            .put("discovery.uri", server.getBaseUrl().toString())
-            .put("discovery.apple.pool", "red")
-            .build();
+                .put("discovery.uri", server.getBaseUrl().toString())
+                .put("discovery.apple.pool", "red")
+                .build();
 
         Bootstrap bootstrap = new Bootstrap(
                 new TestingNodeModule("testing"),
                 new JsonModule(),
                 new DiscoveryModule(),
-                new Module() {
+                new Module()
+                {
                     @Override
                     public void configure(Binder binder)
                     {

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncement.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Resources;
+import org.testng.annotations.Test;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static com.facebook.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static com.facebook.airlift.testing.ValidationAssertions.assertValidates;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestDynamicAnnouncement
+{
+    @Test
+    public void testRejectsNullEnvironment()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement(null, "pool", "/location", Collections.<DynamicServiceAnnouncement>emptySet());
+        assertFailsValidation(announcement, "environment", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testAllowsNullLocation()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "pool", null, Collections.<DynamicServiceAnnouncement>emptySet());
+
+        assertValidates(announcement);
+    }
+
+    @Test
+    public void testRejectsNullPool()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", null, "/location", Collections.<DynamicServiceAnnouncement>emptySet());
+        assertFailsValidation(announcement, "pool", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testRejectsNullServiceAnnouncements()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "pool", "/location", null);
+        assertFailsValidation(announcement, "serviceAnnouncements", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testValidatesNestedServiceAnnouncements()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "pool", "/location", ImmutableSet.of(
+                new DynamicServiceAnnouncement(null, "type", Collections.<String, String>emptyMap()))
+        );
+
+        assertFailsValidation(announcement, "serviceAnnouncements[].id", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testParsing()
+            throws IOException
+    {
+        JsonCodec<DynamicAnnouncement> codec = JsonCodec.jsonCodec(DynamicAnnouncement.class);
+
+        DynamicAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("announcement.json"), Charsets.UTF_8));
+
+        DynamicServiceAnnouncement red = new DynamicServiceAnnouncement(Id.<Service>valueOf("1c001650-7841-11e0-a1f0-0800200c9a66"), "red", ImmutableMap.of("key", "redValue"));
+        DynamicServiceAnnouncement blue = new DynamicServiceAnnouncement(Id.<Service>valueOf("2a817750-7841-11e0-a1f0-0800200c9a66"), "blue", ImmutableMap.of("key", "blueValue"));
+        DynamicAnnouncement expected = new DynamicAnnouncement("testing", "poolA", "/a/b/c", ImmutableSet.of(red, blue));
+
+        assertEquals(parsed, expected);
+    }
+
+    @Test
+    public void testToString()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "pool", "/location", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "type", Collections.<String, String>emptyMap()))
+        );
+
+        assertNotNull(announcement.toString());
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncement.java
@@ -16,7 +16,6 @@
 package com.facebook.airlift.discovery.server;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
@@ -25,6 +24,7 @@ import org.testng.annotations.Test;
 import javax.validation.constraints.NotNull;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import static com.facebook.airlift.testing.ValidationAssertions.assertFailsValidation;
@@ -78,7 +78,7 @@ public class TestDynamicAnnouncement
     {
         JsonCodec<DynamicAnnouncement> codec = JsonCodec.jsonCodec(DynamicAnnouncement.class);
 
-        DynamicAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("announcement.json"), Charsets.UTF_8));
+        DynamicAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("announcement.json"), StandardCharsets.UTF_8));
 
         DynamicServiceAnnouncement red = new DynamicServiceAnnouncement(Id.<Service>valueOf("1c001650-7841-11e0-a1f0-0800200c9a66"), "red", ImmutableMap.of("key", "redValue"));
         DynamicServiceAnnouncement blue = new DynamicServiceAnnouncement(Id.<Service>valueOf("2a817750-7841-11e0-a1f0-0800200c9a66"), "blue", ImmutableMap.of("key", "blueValue"));

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncement.java
@@ -67,8 +67,7 @@ public class TestDynamicAnnouncement
     public void testValidatesNestedServiceAnnouncements()
     {
         DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "pool", "/location", ImmutableSet.of(
-                new DynamicServiceAnnouncement(null, "type", Collections.<String, String>emptyMap()))
-        );
+                new DynamicServiceAnnouncement(null, "type", Collections.<String, String>emptyMap())));
 
         assertFailsValidation(announcement, "serviceAnnouncements[].id", "may not be null", NotNull.class);
     }
@@ -92,8 +91,7 @@ public class TestDynamicAnnouncement
     public void testToString()
     {
         DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "pool", "/location", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "type", Collections.<String, String>emptyMap()))
-        );
+                new DynamicServiceAnnouncement(Id.<Service>random(), "type", Collections.<String, String>emptyMap())));
 
         assertNotNull(announcement.toString());
     }

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncementResource.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncementResource.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.discovery.store.RealTimeSupplier;
+import com.facebook.airlift.jaxrs.testing.MockUriInfo;
+import com.facebook.airlift.node.NodeInfo;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+
+import java.net.URI;
+
+import static com.facebook.airlift.discovery.server.DynamicServiceAnnouncement.toServiceWith;
+import static com.facebook.airlift.testing.Assertions.assertEqualsIgnoreOrder;
+import static com.google.common.collect.Iterables.transform;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestDynamicAnnouncementResource
+{
+    private InMemoryDynamicStore store;
+    private DynamicAnnouncementResource resource;
+
+    @BeforeMethod
+    public void setup()
+    {
+        store = new InMemoryDynamicStore(new DiscoveryConfig(), new RealTimeSupplier());
+        resource = new DynamicAnnouncementResource(store, new NodeInfo("testing"));
+    }
+
+    @Test
+    public void testPutNew()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")))
+        );
+
+        Id<Node> nodeId = Id.random();
+        Response response = resource.put(nodeId, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/" + nodeId.toString())), announcement);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+
+        assertEqualsIgnoreOrder(store.getAll(), transform(announcement.getServiceAnnouncements(), toServiceWith(nodeId, announcement.getLocation(), announcement.getPool())));
+    }
+
+    @Test
+    public void testReplace()
+    {
+        Id<Node> nodeId = Id.random();
+        DynamicAnnouncement previous = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "existing"))
+        ));
+
+        store.put(nodeId, previous);
+
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "new")))
+        );
+
+        Response response = resource.put(nodeId, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/" + nodeId.toString())), announcement);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+
+        assertEqualsIgnoreOrder(store.getAll(), transform(announcement.getServiceAnnouncements(), toServiceWith(nodeId, announcement.getLocation(), announcement.getPool())));
+    }
+
+    @Test
+    public void testEnvironmentConflict()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement("production", "alpha", "/a/b/c", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")))
+        );
+
+        Id<Node> nodeId = Id.random();
+        Response response = resource.put(nodeId, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/" + nodeId.toString())), announcement);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+
+        assertTrue(store.getAll().isEmpty());
+    }
+
+    @Test
+    public void testDeleteExisting()
+    {
+        Id<Node> blueNodeId = Id.random();
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "valueBlue"))
+        ));
+
+        Id<Node> redNodeId = Id.random();
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "valueBlue"))
+        ));
+
+        store.put(redNodeId, red);
+        store.put(blueNodeId, blue);
+
+        Response response = resource.delete(blueNodeId);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        assertEqualsIgnoreOrder(store.getAll(), transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool())));
+    }
+
+    @Test
+    public void testDeleteMissing()
+    {
+        Response response = resource.delete(Id.<Node>random());
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.NO_CONTENT.getStatusCode());
+
+        assertTrue(store.getAll().isEmpty());
+    }
+
+    @Test
+    public void testMakesUpLocation()
+    {
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "alpha", null, ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")))
+        );
+
+        Id<Node> nodeId = Id.valueOf("test123");
+        Response response = resource.put(nodeId, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/" + nodeId.toString())), announcement);
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+
+        assertEquals(store.getAll().size(), 1);
+        Service service = store.getAll().iterator().next();
+        assertEquals(service.getId(), service.getId());
+        assertNotNull(service.getLocation());
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncementResource.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncementResource.java
@@ -50,8 +50,7 @@ public class TestDynamicAnnouncementResource
     public void testPutNew()
     {
         DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")))
-        );
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         Id<Node> nodeId = Id.random();
         Response response = resource.put(nodeId, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/" + nodeId.toString())), announcement);
@@ -67,14 +66,12 @@ public class TestDynamicAnnouncementResource
     {
         Id<Node> nodeId = Id.random();
         DynamicAnnouncement previous = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "existing"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "existing"))));
 
         store.put(nodeId, previous);
 
         DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "new")))
-        );
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "new"))));
 
         Response response = resource.put(nodeId, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/" + nodeId.toString())), announcement);
 
@@ -88,8 +85,7 @@ public class TestDynamicAnnouncementResource
     public void testEnvironmentConflict()
     {
         DynamicAnnouncement announcement = new DynamicAnnouncement("production", "alpha", "/a/b/c", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")))
-        );
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         Id<Node> nodeId = Id.random();
         Response response = resource.put(nodeId, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/" + nodeId.toString())), announcement);
@@ -105,13 +101,11 @@ public class TestDynamicAnnouncementResource
     {
         Id<Node> blueNodeId = Id.random();
         DynamicAnnouncement blue = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "valueBlue"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "valueBlue"))));
 
         Id<Node> redNodeId = Id.random();
         DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "valueBlue"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "valueBlue"))));
 
         store.put(redNodeId, red);
         store.put(blueNodeId, blue);
@@ -139,8 +133,7 @@ public class TestDynamicAnnouncementResource
     public void testMakesUpLocation()
     {
         DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "alpha", null, ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")))
-        );
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         Id<Node> nodeId = Id.valueOf("test123");
         Response response = resource.put(nodeId, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/" + nodeId.toString())), announcement);

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncementResource.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicAnnouncementResource.java
@@ -29,7 +29,7 @@ import java.net.URI;
 
 import static com.facebook.airlift.discovery.server.DynamicServiceAnnouncement.toServiceWith;
 import static com.facebook.airlift.testing.Assertions.assertEqualsIgnoreOrder;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -58,7 +58,7 @@ public class TestDynamicAnnouncementResource
         assertNotNull(response);
         assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
-        assertEqualsIgnoreOrder(store.getAll(), transform(announcement.getServiceAnnouncements(), toServiceWith(nodeId, announcement.getLocation(), announcement.getPool())));
+        assertEqualsIgnoreOrder(store.getAll(), announcement.getServiceAnnouncements().stream().map(toServiceWith(nodeId, announcement.getLocation(), announcement.getPool())).collect(toImmutableList()));
     }
 
     @Test
@@ -78,7 +78,7 @@ public class TestDynamicAnnouncementResource
         assertNotNull(response);
         assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
-        assertEqualsIgnoreOrder(store.getAll(), transform(announcement.getServiceAnnouncements(), toServiceWith(nodeId, announcement.getLocation(), announcement.getPool())));
+        assertEqualsIgnoreOrder(store.getAll(), announcement.getServiceAnnouncements().stream().map(toServiceWith(nodeId, announcement.getLocation(), announcement.getPool())).collect(toImmutableList()));
     }
 
     @Test
@@ -115,7 +115,7 @@ public class TestDynamicAnnouncementResource
         assertNotNull(response);
         assertEquals(response.getStatus(), Response.Status.NO_CONTENT.getStatusCode());
 
-        assertEqualsIgnoreOrder(store.getAll(), transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool())));
+        assertEqualsIgnoreOrder(store.getAll(), red.getServiceAnnouncements().stream().map(toServiceWith(redNodeId, red.getLocation(), red.getPool())).collect(toImmutableList()));
     }
 
     @Test

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicServiceAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicServiceAnnouncement.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.io.Resources;
+import org.testng.annotations.Test;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.facebook.airlift.testing.Assertions.assertNotEquals;
+import static com.facebook.airlift.testing.EquivalenceTester.equivalenceTester;
+import static com.facebook.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestDynamicServiceAnnouncement
+{
+    @Test
+    public void testValidatesNullId()
+    {
+        DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement(null, "type", Collections.<String, String>emptyMap());
+        assertFailsValidation(announcement, "id", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testValidatesNullType()
+    {
+        DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement(Id.<Service>random(), null, Collections.<String, String>emptyMap());
+        assertFailsValidation(announcement, "type", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testValidatesNullProperties()
+    {
+        DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement(Id.<Service>random(), "type", null);
+        assertFailsValidation(announcement, "properties", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testParsing()
+            throws IOException
+    {
+        JsonCodec<DynamicServiceAnnouncement> codec = JsonCodec.jsonCodec(DynamicServiceAnnouncement.class);
+
+        DynamicServiceAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("dynamic-announcement.json"), Charsets.UTF_8));
+        DynamicServiceAnnouncement expected = new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueA"));
+
+        assertEquals(parsed, expected);
+    }
+
+    @Test
+    public void testEquivalence()
+    {
+        equivalenceTester()
+                // vary fields, one by one
+                .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueA")),
+                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueB")),
+                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueB")))
+                .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "red", ImmutableMap.of("key", "valueA")),
+                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "red", ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("4960d071-67b0-4552-8b12-b7abd869aa83"), "blue", ImmutableMap.of("key", "valueA")),
+                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("4960d071-67b0-4552-8b12-b7abd869aa83"), "blue", ImmutableMap.of("key", "valueA")))
+                // null fields
+                .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", null),
+                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", null))
+                .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), null, ImmutableMap.of("key", "valueA")),
+                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), null, ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new DynamicServiceAnnouncement(null, "blue", ImmutableMap.of("key", "valueA")),
+                                    new DynamicServiceAnnouncement(null, "blue", ImmutableMap.of("key", "valueA")))
+
+                // empty properties
+                .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", Collections.<String, String>emptyMap()),
+                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", Collections.<String, String>emptyMap()))
+                .check();
+    }
+
+    @Test
+    public void testCreatesDefensiveCopyOfProperties()
+    {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key", "value");
+        DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement(Id.<Service>random(), "type", properties);
+
+        assertEquals(announcement.getProperties(), properties);
+        properties.put("key2", "value2");
+        assertNotEquals(announcement.getProperties(), properties);
+    }
+
+    @Test
+    public void testImmutableProperties()
+    {
+        DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement (Id.<Service>random(), "type", ImmutableMap.of("key", "value"));
+
+        try {
+            announcement.getProperties().put("key2", "value2");
+
+            // a copy of the internal map is acceptable
+            assertEquals(announcement.getProperties(), ImmutableMap.of("key", "value"));
+        }
+        catch (UnsupportedOperationException e) {
+            // an exception is ok, too
+        }
+    }
+
+    @Test
+    public void testToString()
+    {
+        DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueA"));
+
+        assertNotNull(announcement.toString());
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicServiceAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicServiceAnnouncement.java
@@ -75,24 +75,24 @@ public class TestDynamicServiceAnnouncement
         equivalenceTester()
                 // vary fields, one by one
                 .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueA")),
-                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueA")))
+                        new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueB")),
-                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueB")))
+                        new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueB")))
                 .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "red", ImmutableMap.of("key", "valueA")),
-                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "red", ImmutableMap.of("key", "valueA")))
+                        new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "red", ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("4960d071-67b0-4552-8b12-b7abd869aa83"), "blue", ImmutableMap.of("key", "valueA")),
-                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("4960d071-67b0-4552-8b12-b7abd869aa83"), "blue", ImmutableMap.of("key", "valueA")))
+                        new DynamicServiceAnnouncement(Id.<Service>valueOf("4960d071-67b0-4552-8b12-b7abd869aa83"), "blue", ImmutableMap.of("key", "valueA")))
                 // null fields
                 .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", null),
-                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", null))
+                        new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", null))
                 .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), null, ImmutableMap.of("key", "valueA")),
-                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), null, ImmutableMap.of("key", "valueA")))
+                        new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), null, ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new DynamicServiceAnnouncement(null, "blue", ImmutableMap.of("key", "valueA")),
-                                    new DynamicServiceAnnouncement(null, "blue", ImmutableMap.of("key", "valueA")))
+                        new DynamicServiceAnnouncement(null, "blue", ImmutableMap.of("key", "valueA")))
 
                 // empty properties
                 .addEquivalentGroup(new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", Collections.<String, String>emptyMap()),
-                                    new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", Collections.<String, String>emptyMap()))
+                        new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", Collections.<String, String>emptyMap()))
                 .check();
     }
 
@@ -111,7 +111,7 @@ public class TestDynamicServiceAnnouncement
     @Test
     public void testImmutableProperties()
     {
-        DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement (Id.<Service>random(), "type", ImmutableMap.of("key", "value"));
+        DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement(Id.<Service>random(), "type", ImmutableMap.of("key", "value"));
 
         try {
             announcement.getProperties().put("key2", "value2");

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicServiceAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicServiceAnnouncement.java
@@ -16,16 +16,16 @@
 package com.facebook.airlift.discovery.server;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import org.testng.annotations.Test;
 
 import javax.validation.constraints.NotNull;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.facebook.airlift.testing.Assertions.assertNotEquals;
@@ -63,7 +63,7 @@ public class TestDynamicServiceAnnouncement
     {
         JsonCodec<DynamicServiceAnnouncement> codec = JsonCodec.jsonCodec(DynamicServiceAnnouncement.class);
 
-        DynamicServiceAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("dynamic-announcement.json"), Charsets.UTF_8));
+        DynamicServiceAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("dynamic-announcement.json"), StandardCharsets.UTF_8));
         DynamicServiceAnnouncement expected = new DynamicServiceAnnouncement(Id.<Service>valueOf("ff824508-b6a6-4dfc-8f0b-85028465534d"), "blue", ImmutableMap.of("key", "valueA"));
 
         assertEquals(parsed, expected);
@@ -99,7 +99,7 @@ public class TestDynamicServiceAnnouncement
     @Test
     public void testCreatesDefensiveCopyOfProperties()
     {
-        Map<String, String> properties = Maps.newHashMap();
+        Map<String, String> properties = new HashMap<>();
         properties.put("key", "value");
         DynamicServiceAnnouncement announcement = new DynamicServiceAnnouncement(Id.<Service>random(), "type", properties);
 

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicStore.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.discovery.server.DynamicServiceAnnouncement.toServiceWith;
+import static com.facebook.airlift.testing.Assertions.assertEqualsIgnoreOrder;
+import static com.google.common.collect.Collections2.transform;
+import static com.google.common.collect.Iterables.concat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public abstract class TestDynamicStore
+{
+    private static final Duration MAX_AGE = new Duration(1, TimeUnit.MINUTES);
+
+    protected TestingTimeSupplier currentTime;
+    protected DynamicStore store;
+
+    protected abstract DynamicStore initializeStore(DiscoveryConfig config, Supplier<DateTime> timeSupplier);
+
+    @BeforeMethod
+    public void setup()
+    {
+        currentTime = new TestingTimeSupplier();
+        DiscoveryConfig config = new DiscoveryConfig()
+                .setMaxAge(new Duration(1, TimeUnit.MINUTES))
+                .setStoreCacheTtl(new Duration(0, TimeUnit.SECONDS));
+        store = initializeStore(config, currentTime);
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertTrue(store.getAll().isEmpty(), "store should be empty");
+    }
+
+    @Test
+    public void testPutSingle()
+    {
+        Id<Node> nodeId = Id.random();
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
+        ));
+
+        store.put(nodeId, blue);
+
+        assertEquals(store.getAll(), transform(blue.getServiceAnnouncements(), toServiceWith(nodeId, blue.getLocation(), blue.getPool())));
+    }
+
+    @Test
+    public void testExpires()
+    {
+        Id<Node> nodeId = Id.random();
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
+        ));
+
+        store.put(nodeId, blue);
+        advanceTimeBeyondMaxAge();
+        assertEquals(store.getAll(), Collections.<Service>emptySet());
+    }
+
+    @Test
+    public void testPutMultipleForSameNode()
+    {
+        Id<Node> nodeId = Id.random();
+        DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")),
+                new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("http", "http://localhost:2222")),
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))
+        ));
+
+        store.put(nodeId, announcement);
+
+        assertEqualsIgnoreOrder(store.getAll(), transform(announcement.getServiceAnnouncements(), toServiceWith(nodeId, announcement.getLocation(), announcement.getPool())));
+    }
+
+    @Test
+    public void testReplace()
+    {
+        Id<Node> nodeId = Id.random();
+
+        DynamicAnnouncement oldAnnouncement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
+        ));
+
+        DynamicAnnouncement newAnnouncement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))
+        ));
+
+        store.put(nodeId, oldAnnouncement);
+        currentTime.increment();
+        store.put(nodeId, newAnnouncement);
+
+        assertEquals(store.getAll(), transform(newAnnouncement.getServiceAnnouncements(), toServiceWith(nodeId, newAnnouncement.getLocation(), newAnnouncement.getPool())));
+    }
+
+    @Test
+    public void testReplaceExpired()
+    {
+        Id<Node> nodeId = Id.random();
+
+        DynamicAnnouncement oldAnnouncement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
+        ));
+
+        DynamicAnnouncement newAnnouncement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))
+        ));
+
+        store.put(nodeId, oldAnnouncement);
+        advanceTimeBeyondMaxAge();
+        store.put(nodeId, newAnnouncement);
+
+        assertEqualsIgnoreOrder(store.getAll(), transform(newAnnouncement.getServiceAnnouncements(), toServiceWith(nodeId, newAnnouncement.getLocation(), newAnnouncement.getPool())));
+    }
+
+    @Test
+    public void testPutMultipleForDifferentNodes()
+    {
+        Id<Node> blueNodeId = Id.random();
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
+        ));
+
+        Id<Node> redNodeId = Id.random();
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("http", "http://localhost:2222"))
+        ));
+
+        Id<Node> greenNodeId = Id.random();
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot3", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))
+        ));
+
+        store.put(blueNodeId, blue);
+        store.put(redNodeId, red);
+        store.put(greenNodeId, green);
+
+        assertEqualsIgnoreOrder(store.getAll(), concat(
+                transform(blue.getServiceAnnouncements(), toServiceWith(blueNodeId, blue.getLocation(), blue.getPool())),
+                transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool())),
+                transform(green.getServiceAnnouncements(), toServiceWith(greenNodeId, green.getLocation(), green.getPool()))));
+    }
+
+    @Test
+    public void testGetByType()
+    {
+        Id<Node> blueNodeId = Id.random();
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
+        ));
+
+        Id<Node> redNodeId = Id.random();
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))
+        ));
+
+        Id<Node> greenNodeId = Id.random();
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot3", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))
+        ));
+
+        store.put(blueNodeId, blue);
+        store.put(redNodeId, red);
+        store.put(greenNodeId, green);
+
+        assertEqualsIgnoreOrder(store.get("storage"), concat(
+                transform(blue.getServiceAnnouncements(), toServiceWith(blueNodeId, blue.getLocation(), blue.getPool())),
+                transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool()))));
+
+        assertEqualsIgnoreOrder(store.get("monitoring"), transform(green.getServiceAnnouncements(), toServiceWith(greenNodeId, green.getLocation(), green.getPool())));
+    }
+
+    @Test
+    public void testGetByTypeAndPool()
+    {
+        Id<Node> blueNodeId = Id.random();
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
+        ));
+
+        Id<Node> redNodeId = Id.random();
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))
+        ));
+
+        Id<Node> greenNodeId = Id.random();
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot3", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))
+        ));
+
+        Id<Node> yellowNodeId = Id.random();
+        DynamicAnnouncement yellow = new DynamicAnnouncement("testing", "poolB", "/US/West/SC4/rack1/host1/vm1/slot4", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:4444"))
+        ));
+
+        store.put(blueNodeId, blue);
+        store.put(redNodeId, red);
+        store.put(greenNodeId, green);
+        store.put(yellowNodeId, yellow);
+
+        assertEqualsIgnoreOrder(store.get("storage", "poolA"), concat(
+                transform(blue.getServiceAnnouncements(), toServiceWith(blueNodeId, blue.getLocation(), blue.getPool())),
+                transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool()))));
+
+        assertEqualsIgnoreOrder(store.get("monitoring", "poolA"),
+                transform(green.getServiceAnnouncements(), toServiceWith(greenNodeId, red.getLocation(), red.getPool())));
+
+        assertEqualsIgnoreOrder(store.get("storage", "poolB"),
+                transform(yellow.getServiceAnnouncements(), toServiceWith(yellowNodeId, red.getLocation(), red.getPool())));
+    }
+
+    @Test
+    public void testDelete()
+    {
+        Id<Node> blueNodeId = Id.random();
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")),
+                new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("http", "http://localhost:2222"))
+        ));
+
+        Id<Node> redNodeId = Id.random();
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:2222"))
+        ));
+
+        store.put(blueNodeId, blue);
+        store.put(redNodeId, red);
+
+        assertEqualsIgnoreOrder(store.getAll(), concat(
+                transform(blue.getServiceAnnouncements(), toServiceWith(blueNodeId, blue.getLocation(), blue.getPool())),
+                transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool()))));
+
+        currentTime.increment();
+
+        store.delete(blueNodeId);
+
+        assertEqualsIgnoreOrder(store.getAll(), transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool())));
+
+        assertTrue(store.get("storage").isEmpty());
+        assertTrue(store.get("web", "poolA").isEmpty());
+    }
+
+    @Test
+    public void testDeleteThenReInsert()
+    {
+        Id<Node> redNodeId = Id.random();
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:2222"))
+        ));
+
+        store.put(redNodeId, red);
+        assertEqualsIgnoreOrder(store.getAll(), transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool())));
+
+        currentTime.increment();
+
+        store.delete(redNodeId);
+
+        currentTime.increment();
+
+        store.put(redNodeId, red);
+
+        assertEqualsIgnoreOrder(store.getAll(), transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool())));
+    }
+
+    @Test
+    public void testCanHandleLotsOfAnnouncements()
+    {
+        ImmutableSet.Builder<Service> builder = ImmutableSet.builder();
+        for (int i = 0; i < 5000; ++i) {
+            Id<Node> id = Id.random();
+            DynamicServiceAnnouncement serviceAnnouncement = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"));
+            DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(serviceAnnouncement));
+
+            store.put(id, announcement);
+            builder.add(new Service(serviceAnnouncement.getId(),
+                                    id,
+                                    serviceAnnouncement.getType(),
+                                    announcement.getPool(),
+                                    announcement.getLocation(),
+                                    serviceAnnouncement.getProperties()));
+        }
+
+        assertEqualsIgnoreOrder(store.getAll(), builder.build());
+    }
+
+
+    private void advanceTimeBeyondMaxAge()
+    {
+        currentTime.add(new Duration(MAX_AGE.toMillis() * 2, TimeUnit.MILLISECONDS));
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicStore.java
@@ -63,8 +63,7 @@ public abstract class TestDynamicStore
     {
         Id<Node> nodeId = Id.random();
         DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         store.put(nodeId, blue);
 
@@ -76,8 +75,7 @@ public abstract class TestDynamicStore
     {
         Id<Node> nodeId = Id.random();
         DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         store.put(nodeId, blue);
         advanceTimeBeyondMaxAge();
@@ -91,8 +89,7 @@ public abstract class TestDynamicStore
         DynamicAnnouncement announcement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
                 new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")),
                 new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("http", "http://localhost:2222")),
-                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))));
 
         store.put(nodeId, announcement);
 
@@ -105,12 +102,10 @@ public abstract class TestDynamicStore
         Id<Node> nodeId = Id.random();
 
         DynamicAnnouncement oldAnnouncement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         DynamicAnnouncement newAnnouncement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))));
 
         store.put(nodeId, oldAnnouncement);
         currentTime.increment();
@@ -125,12 +120,10 @@ public abstract class TestDynamicStore
         Id<Node> nodeId = Id.random();
 
         DynamicAnnouncement oldAnnouncement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         DynamicAnnouncement newAnnouncement = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))));
 
         store.put(nodeId, oldAnnouncement);
         advanceTimeBeyondMaxAge();
@@ -144,18 +137,15 @@ public abstract class TestDynamicStore
     {
         Id<Node> blueNodeId = Id.random();
         DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         Id<Node> redNodeId = Id.random();
         DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("http", "http://localhost:2222"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("http", "http://localhost:2222"))));
 
         Id<Node> greenNodeId = Id.random();
         DynamicAnnouncement green = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot3", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))));
 
         store.put(blueNodeId, blue);
         store.put(redNodeId, red);
@@ -172,18 +162,15 @@ public abstract class TestDynamicStore
     {
         Id<Node> blueNodeId = Id.random();
         DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         Id<Node> redNodeId = Id.random();
         DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))));
 
         Id<Node> greenNodeId = Id.random();
         DynamicAnnouncement green = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot3", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))));
 
         store.put(blueNodeId, blue);
         store.put(redNodeId, red);
@@ -201,23 +188,19 @@ public abstract class TestDynamicStore
     {
         Id<Node> blueNodeId = Id.random();
         DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111"))));
 
         Id<Node> redNodeId = Id.random();
         DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:2222"))));
 
         Id<Node> greenNodeId = Id.random();
         DynamicAnnouncement green = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot3", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:3333"))));
 
         Id<Node> yellowNodeId = Id.random();
         DynamicAnnouncement yellow = new DynamicAnnouncement("testing", "poolB", "/US/West/SC4/rack1/host1/vm1/slot4", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:4444"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:4444"))));
 
         store.put(blueNodeId, blue);
         store.put(redNodeId, red);
@@ -241,13 +224,11 @@ public abstract class TestDynamicStore
         Id<Node> blueNodeId = Id.random();
         DynamicAnnouncement blue = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableSet.of(
                 new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("http", "http://localhost:1111")),
-                new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("http", "http://localhost:2222"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("http", "http://localhost:2222"))));
 
         Id<Node> redNodeId = Id.random();
         DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:2222"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:2222"))));
 
         store.put(blueNodeId, blue);
         store.put(redNodeId, red);
@@ -271,8 +252,7 @@ public abstract class TestDynamicStore
     {
         Id<Node> redNodeId = Id.random();
         DynamicAnnouncement red = new DynamicAnnouncement("testing", "poolA", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableSet.of(
-                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:2222"))
-        ));
+                new DynamicServiceAnnouncement(Id.<Service>random(), "monitoring", ImmutableMap.of("http", "http://localhost:2222"))));
 
         store.put(redNodeId, red);
         assertEqualsIgnoreOrder(store.getAll(), transform(red.getServiceAnnouncements(), toServiceWith(redNodeId, red.getLocation(), red.getPool())));
@@ -299,16 +279,15 @@ public abstract class TestDynamicStore
 
             store.put(id, announcement);
             builder.add(new Service(serviceAnnouncement.getId(),
-                                    id,
-                                    serviceAnnouncement.getType(),
-                                    announcement.getPool(),
-                                    announcement.getLocation(),
-                                    serviceAnnouncement.getProperties()));
+                    id,
+                    serviceAnnouncement.getType(),
+                    announcement.getPool(),
+                    announcement.getLocation(),
+                    serviceAnnouncement.getProperties()));
         }
 
         assertEqualsIgnoreOrder(store.getAll(), builder.build());
     }
-
 
     private void advanceTimeBeyondMaxAge()
     {

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestDynamicStore.java
@@ -15,9 +15,9 @@
  */
 package com.facebook.airlift.discovery.server;
 
+import com.facebook.airlift.units.Duration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import io.airlift.units.Duration;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestId.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestId.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static org.testng.Assert.assertEquals;
+
+
+public class TestId
+{
+    @Test
+    public void testToJson()
+    {
+        Holder holder = new Holder(Id.<Holder>random());
+        Map<String, String> expected = ImmutableMap.of("id", holder.getId().toString());
+
+        String json = jsonCodec(Holder.class).toJson(holder);
+
+        assertEquals(jsonCodec(Object.class).fromJson(json), expected);
+    }
+
+    @Test
+    public void testFromJson()
+    {
+        String value = "abc/123";
+
+        Id<Holder> id = Id.valueOf(value);
+        assertEquals(id.get(), value);
+
+        Map<String, String> map = ImmutableMap.of("id", id.toString());
+        String json = jsonCodec(Object.class).toJson(map);
+
+        assertEquals(jsonCodec(Holder.class).fromJson(json).getId(), id);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "id is null")
+    public void testNullId()
+    {
+        Id.valueOf(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "id is empty")
+    public void testEmptyId()
+    {
+        Id.valueOf("");
+    }
+
+    public static class Holder
+    {
+        private final Id<Holder> id;
+
+        @JsonCreator
+        public Holder(@JsonProperty("id") Id<Holder> id)
+        {
+            this.id = id;
+        }
+
+        @JsonProperty
+        public Id<Holder> getId()
+        {
+            return id;
+        }
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestId.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestId.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static org.testng.Assert.assertEquals;
 
-
 public class TestId
 {
     @Test

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestInMemoryDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestInMemoryDynamicStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.common.base.Supplier;
+import org.joda.time.DateTime;
+
+public class TestInMemoryDynamicStore
+        extends TestDynamicStore
+{
+    @Override
+    public DynamicStore initializeStore(DiscoveryConfig config, Supplier<DateTime> timeSupplier)
+    {
+        return new InMemoryDynamicStore(config, timeSupplier);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestInMemoryDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestInMemoryDynamicStore.java
@@ -15,14 +15,14 @@
  */
 package com.facebook.airlift.discovery.server;
 
-import com.google.common.base.Supplier;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
 
 public class TestInMemoryDynamicStore
         extends TestDynamicStore
 {
     @Override
-    public DynamicStore initializeStore(DiscoveryConfig config, Supplier<DateTime> timeSupplier)
+    public DynamicStore initializeStore(DiscoveryConfig config, Supplier<ZonedDateTime> timeSupplier)
     {
         return new InMemoryDynamicStore(config, timeSupplier);
     }

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestInMemoryStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestInMemoryStaticStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.common.base.Supplier;
+import org.joda.time.DateTime;
+
+public class TestInMemoryStaticStore
+        extends TestStaticStore
+{
+    @Override
+    protected StaticStore initializeStore(Supplier<DateTime> timeSupplier)
+    {
+        return new InMemoryStaticStore();
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestInMemoryStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestInMemoryStaticStore.java
@@ -15,14 +15,14 @@
  */
 package com.facebook.airlift.discovery.server;
 
-import com.google.common.base.Supplier;
-import org.joda.time.DateTime;
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
 
 public class TestInMemoryStaticStore
         extends TestStaticStore
 {
     @Override
-    protected StaticStore initializeStore(Supplier<DateTime> timeSupplier)
+    protected StaticStore initializeStore(Supplier<ZonedDateTime> timeSupplier)
     {
         return new InMemoryStaticStore();
     }

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedDynamicStore.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.discovery.store.ConflictResolver;
+import com.facebook.airlift.discovery.store.DistributedStore;
+import com.facebook.airlift.discovery.store.Entry;
+import com.facebook.airlift.discovery.store.InMemoryStore;
+import com.facebook.airlift.discovery.store.RemoteStore;
+import com.facebook.airlift.discovery.store.StoreConfig;
+import com.google.common.base.Supplier;
+import org.joda.time.DateTime;
+
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+
+public class TestReplicatedDynamicStore
+    extends TestDynamicStore
+{
+    @Override
+    protected DynamicStore initializeStore(DiscoveryConfig config, Supplier<DateTime> timeSupplier)
+    {
+        RemoteStore dummy = new RemoteStore() {
+            public void put(Entry entry) { }
+        };
+
+        DistributedStore distributedStore = new DistributedStore("dynamic", new InMemoryStore(new ConflictResolver()), dummy, new StoreConfig(), timeSupplier);
+
+        return new ReplicatedDynamicStore(distributedStore, config, listJsonCodec(Service.class));
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedDynamicStore.java
@@ -27,13 +27,14 @@ import org.joda.time.DateTime;
 import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 
 public class TestReplicatedDynamicStore
-    extends TestDynamicStore
+        extends TestDynamicStore
 {
     @Override
     protected DynamicStore initializeStore(DiscoveryConfig config, Supplier<DateTime> timeSupplier)
     {
-        RemoteStore dummy = new RemoteStore() {
-            public void put(Entry entry) { }
+        RemoteStore dummy = new RemoteStore()
+        {
+            public void put(Entry entry) {}
         };
 
         DistributedStore distributedStore = new DistributedStore("dynamic", new InMemoryStore(new ConflictResolver()), dummy, new StoreConfig(), timeSupplier);

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedDynamicStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedDynamicStore.java
@@ -21,8 +21,9 @@ import com.facebook.airlift.discovery.store.Entry;
 import com.facebook.airlift.discovery.store.InMemoryStore;
 import com.facebook.airlift.discovery.store.RemoteStore;
 import com.facebook.airlift.discovery.store.StoreConfig;
-import com.google.common.base.Supplier;
-import org.joda.time.DateTime;
+
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
 
 import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 
@@ -30,7 +31,7 @@ public class TestReplicatedDynamicStore
         extends TestDynamicStore
 {
     @Override
-    protected DynamicStore initializeStore(DiscoveryConfig config, Supplier<DateTime> timeSupplier)
+    protected DynamicStore initializeStore(DiscoveryConfig config, Supplier<ZonedDateTime> timeSupplier)
     {
         RemoteStore dummy = new RemoteStore()
         {

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedStaticStore.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.discovery.store.ConflictResolver;
+import com.facebook.airlift.discovery.store.DistributedStore;
+import com.facebook.airlift.discovery.store.Entry;
+import com.facebook.airlift.discovery.store.InMemoryStore;
+import com.facebook.airlift.discovery.store.RemoteStore;
+import com.facebook.airlift.discovery.store.StoreConfig;
+import com.google.common.base.Supplier;
+import org.joda.time.DateTime;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+
+public class TestReplicatedStaticStore
+    extends TestStaticStore
+{
+    @Override
+    protected StaticStore initializeStore(Supplier<DateTime> timeSupplier)
+    {
+        RemoteStore dummy = new RemoteStore() {
+            public void put(Entry entry) { }
+        };
+
+        DistributedStore distributedStore = new DistributedStore("static", new InMemoryStore(new ConflictResolver()), dummy, new StoreConfig(), timeSupplier);
+
+        return new ReplicatedStaticStore(distributedStore, jsonCodec(Service.class));
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedStaticStore.java
@@ -17,12 +17,12 @@ package com.facebook.airlift.discovery.server;
 
 import com.facebook.airlift.discovery.store.ConflictResolver;
 import com.facebook.airlift.discovery.store.DistributedStore;
-import com.facebook.airlift.discovery.store.Entry;
 import com.facebook.airlift.discovery.store.InMemoryStore;
 import com.facebook.airlift.discovery.store.RemoteStore;
 import com.facebook.airlift.discovery.store.StoreConfig;
-import com.google.common.base.Supplier;
-import org.joda.time.DateTime;
+
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 
@@ -30,12 +30,9 @@ public class TestReplicatedStaticStore
         extends TestStaticStore
 {
     @Override
-    protected StaticStore initializeStore(Supplier<DateTime> timeSupplier)
+    protected StaticStore initializeStore(Supplier<ZonedDateTime> timeSupplier)
     {
-        RemoteStore dummy = new RemoteStore()
-        {
-            public void put(Entry entry) {}
-        };
+        RemoteStore dummy = entry -> {};
 
         DistributedStore distributedStore = new DistributedStore("static", new InMemoryStore(new ConflictResolver()), dummy, new StoreConfig(), timeSupplier);
 

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedStaticStore.java
@@ -27,13 +27,14 @@ import org.joda.time.DateTime;
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 
 public class TestReplicatedStaticStore
-    extends TestStaticStore
+        extends TestStaticStore
 {
     @Override
     protected StaticStore initializeStore(Supplier<DateTime> timeSupplier)
     {
-        RemoteStore dummy = new RemoteStore() {
-            public void put(Entry entry) { }
+        RemoteStore dummy = new RemoteStore()
+        {
+            public void put(Entry entry) {}
         };
 
         DistributedStore distributedStore = new DistributedStore("static", new InMemoryStore(new ConflictResolver()), dummy, new StoreConfig(), timeSupplier);

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestService.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestService.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.io.Resources;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.facebook.airlift.testing.Assertions.assertNotEquals;
+import static com.facebook.airlift.testing.EquivalenceTester.equivalenceTester;
+import static org.testng.Assert.assertEquals;
+
+public class TestService
+{
+    @Test
+    public void testEquivalence()
+    {
+        equivalenceTester()
+                .addEquivalentGroup(new Service(Id.<Service>valueOf("beb73711-0725-47c3-9305-a69d8c344c1e"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
+                                                ImmutableMap.of("key", "valueA")),
+                                    new Service(Id.<Service>valueOf("beb73711-0725-47c3-9305-a69d8c344c1e"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
+                                                ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new Service(Id.<Service>valueOf("a0592d5d-b42b-4376-a651-be973ad97750"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
+                                                ImmutableMap.of("key", "valueA")),
+                                    new Service(Id.<Service>valueOf("a0592d5d-b42b-4376-a651-be973ad97750"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
+                                                ImmutableMap.of("key", "valueA")))
+                .check();
+    }
+
+    @Test
+    public void testCreatesDefensiveCopyOfProperties()
+    {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key", "value");
+        Service service = new Service(Id.<Service>random(), Id.<Node>random(), "type", "pool", "/location", properties);
+
+        assertEquals(service.getProperties(), properties);
+        properties.put("key2", "value2");
+        assertNotEquals(service.getProperties(), properties);
+    }
+
+    @Test
+    public void testImmutableProperties()
+    {
+        Service service = new Service(Id.<Service>random(), Id.<Node>random(), "type", "pool", "/location", ImmutableMap.of("key", "value"));
+
+        try {
+            service.getProperties().put("key2", "value2");
+
+            // a copy of the internal map is acceptable
+            assertEquals(service.getProperties(), ImmutableMap.of("key", "value"));
+        }
+        catch (UnsupportedOperationException e) {
+            // an exception is ok, too
+        }
+    }
+
+    @Test
+    public void testToJson()
+            throws IOException
+    {
+        JsonCodec<Service> serviceCodec = JsonCodec.jsonCodec(Service.class);
+        Service service = new Service(Id.<Service>valueOf("c0c5be5f-b298-4cfa-922a-3e5954208444"), Id.<Node>valueOf("3ff52f57-04e0-46c3-b606-7497b09dd5c7"), "type", "pool", "/location", ImmutableMap.of("key", "value"));
+
+        String json = serviceCodec.toJson(service);
+
+        JsonCodec<Object> codec = JsonCodec.jsonCodec(Object.class);
+        Object parsed = codec.fromJson(json);
+        Object expected = codec.fromJson(Resources.toString(Resources.getResource("service.json"), Charsets.UTF_8));
+
+        assertEquals(parsed, expected);
+    }
+
+    @Test
+    public void testParseJson()
+            throws IOException
+    {
+        JsonCodec<Service> codec = JsonCodec.jsonCodec(Service.class);
+        Service parsed = codec.fromJson(Resources.toString(Resources.getResource("service.json"), Charsets.UTF_8));
+
+        Service expected = new Service(Id.<Service>valueOf("c0c5be5f-b298-4cfa-922a-3e5954208444"), Id.<Node>valueOf("3ff52f57-04e0-46c3-b606-7497b09dd5c7"), "type", "pool", "/location", ImmutableMap.of("key", "value"));
+
+        assertEquals(parsed, expected);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "id.*")
+    public void testValidatesIdNotNull()
+    {
+        new Service(null, Id.<Node>random(), "type", "pool", "/location", ImmutableMap.of("key", "value"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "type.*")
+    public void testValidatesTypeNotNull()
+    {
+        new Service(Id.<Service>random(), Id.<Node>random(), null, "pool", "/location", ImmutableMap.of("key", "value"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "pool.*")
+    public void testValidatesPoolNotNull()
+    {
+        new Service(Id.<Service>random(), Id.<Node>random(), "type", null, "/location", ImmutableMap.of("key", "value"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "location.*")
+    public void testValidatesLocationNotNull()
+    {
+        new Service(Id.<Service>random(), Id.<Node>random(), "type", "type", null, ImmutableMap.of("key", "value"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "properties.*")
+    public void testValidatesPropertiesNotNull()
+    {
+        new Service(Id.<Service>random(), Id.<Node>random(), "type", "type", "/location", null);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestService.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestService.java
@@ -16,13 +16,13 @@
 package com.facebook.airlift.discovery.server;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.facebook.airlift.testing.Assertions.assertNotEquals;
@@ -49,7 +49,7 @@ public class TestService
     @Test
     public void testCreatesDefensiveCopyOfProperties()
     {
-        Map<String, String> properties = Maps.newHashMap();
+        Map<String, String> properties = new HashMap<>();
         properties.put("key", "value");
         Service service = new Service(Id.<Service>random(), Id.<Node>random(), "type", "pool", "/location", properties);
 
@@ -85,7 +85,7 @@ public class TestService
 
         JsonCodec<Object> codec = JsonCodec.jsonCodec(Object.class);
         Object parsed = codec.fromJson(json);
-        Object expected = codec.fromJson(Resources.toString(Resources.getResource("service.json"), Charsets.UTF_8));
+        Object expected = codec.fromJson(Resources.toString(Resources.getResource("service.json"), StandardCharsets.UTF_8));
 
         assertEquals(parsed, expected);
     }
@@ -95,7 +95,7 @@ public class TestService
             throws IOException
     {
         JsonCodec<Service> codec = JsonCodec.jsonCodec(Service.class);
-        Service parsed = codec.fromJson(Resources.toString(Resources.getResource("service.json"), Charsets.UTF_8));
+        Service parsed = codec.fromJson(Resources.toString(Resources.getResource("service.json"), StandardCharsets.UTF_8));
 
         Service expected = new Service(Id.<Service>valueOf("c0c5be5f-b298-4cfa-922a-3e5954208444"), Id.<Node>valueOf("3ff52f57-04e0-46c3-b606-7497b09dd5c7"), "type", "pool", "/location", ImmutableMap.of("key", "value"));
 

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestService.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestService.java
@@ -36,13 +36,13 @@ public class TestService
     {
         equivalenceTester()
                 .addEquivalentGroup(new Service(Id.<Service>valueOf("beb73711-0725-47c3-9305-a69d8c344c1e"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
-                                                ImmutableMap.of("key", "valueA")),
-                                    new Service(Id.<Service>valueOf("beb73711-0725-47c3-9305-a69d8c344c1e"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
-                                                ImmutableMap.of("key", "valueA")))
+                                ImmutableMap.of("key", "valueA")),
+                        new Service(Id.<Service>valueOf("beb73711-0725-47c3-9305-a69d8c344c1e"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
+                                ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new Service(Id.<Service>valueOf("a0592d5d-b42b-4376-a651-be973ad97750"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
-                                                ImmutableMap.of("key", "valueA")),
-                                    new Service(Id.<Service>valueOf("a0592d5d-b42b-4376-a651-be973ad97750"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
-                                                ImmutableMap.of("key", "valueA")))
+                                ImmutableMap.of("key", "valueA")),
+                        new Service(Id.<Service>valueOf("a0592d5d-b42b-4376-a651-be973ad97750"), Id.<Node>valueOf("3c8285d0-bd0d-4fe2-8321-7ebcd065607b"), "blue", "poolA", "/locationA",
+                                ImmutableMap.of("key", "valueA")))
                 .check();
     }
 

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestServiceResource.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestServiceResource.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.node.NodeInfo;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static com.facebook.airlift.discovery.server.DynamicServiceAnnouncement.toServiceWith;
+import static com.google.common.collect.ImmutableSet.of;
+import static org.testng.Assert.assertEquals;
+
+public class TestServiceResource
+{
+    private InMemoryDynamicStore dynamicStore;
+    private ServiceResource resource;
+
+    @BeforeMethod
+    protected void setUp()
+    {
+        dynamicStore = new InMemoryDynamicStore(new DiscoveryConfig(), new TestingTimeSupplier());
+        resource = new ServiceResource(dynamicStore, new InMemoryStaticStore(), new NodeInfo("testing"));
+    }
+
+    @Test
+    public void testGetByType()
+    {
+        Id<Node> redNodeId = Id.random();
+        DynamicServiceAnnouncement redStorage = new DynamicServiceAnnouncement(Id.<Service>random() , "storage", ImmutableMap.of("key", "1"));
+        DynamicServiceAnnouncement redWeb = new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("key", "2"));
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", of(redStorage, redWeb));
+
+        Id<Node> greenNodeId = Id.random();
+        DynamicServiceAnnouncement greenStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "3"));
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", of(greenStorage));
+
+        Id<Node> blueNodeId = Id.random();
+        DynamicServiceAnnouncement blueStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "4"));
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", of(blueStorage));
+
+        dynamicStore.put(redNodeId, red);
+        dynamicStore.put(greenNodeId, green);
+        dynamicStore.put(blueNodeId, blue);
+
+        assertEquals(resource.getServices("storage"), new Services("testing", of(
+                toServiceWith(redNodeId, red.getLocation(), red.getPool()).apply(redStorage),
+                toServiceWith(greenNodeId, green.getLocation(), green.getPool()).apply(greenStorage),
+                toServiceWith(blueNodeId, blue.getLocation(), blue.getPool()).apply(blueStorage))));
+
+        assertEquals(resource.getServices("web"), new Services("testing", ImmutableSet.of(
+                toServiceWith(redNodeId, red.getLocation(), red.getPool()).apply(redWeb))));
+
+        assertEquals(resource.getServices("unknown"), new Services("testing", Collections.<Service>emptySet()));
+    }
+
+    @Test
+    public void testGetByTypeAndPool()
+    {
+        Id<Node> redNodeId = Id.random();
+        DynamicServiceAnnouncement redStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "1"));
+        DynamicServiceAnnouncement redWeb = new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("key", "2"));
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", of(redStorage, redWeb));
+
+        Id<Node> greenNodeId = Id.random();
+        DynamicServiceAnnouncement greenStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "3"));
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", of(greenStorage));
+
+        Id<Node> blueNodeId = Id.random();
+        DynamicServiceAnnouncement blueStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "4"));
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", of(blueStorage));
+
+        dynamicStore.put(redNodeId, red);
+        dynamicStore.put(greenNodeId, green);
+        dynamicStore.put(blueNodeId, blue);
+
+        assertEquals(resource.getServices("storage", "alpha"), new Services("testing", ImmutableSet.of(
+                toServiceWith(redNodeId, red.getLocation(), red.getPool()).apply(redStorage),
+                toServiceWith(greenNodeId, green.getLocation(), green.getPool()).apply(greenStorage))));
+
+        assertEquals(resource.getServices("storage", "beta"), new Services("testing", ImmutableSet.of(toServiceWith(blueNodeId, blue.getLocation(), blue.getPool()).apply(blueStorage))));
+
+        assertEquals(resource.getServices("storage", "unknown"), new Services("testing", Collections.<Service>emptySet()));
+    }
+
+    @Test
+    public void testGetAll()
+    {
+        Id<Node> redNodeId = Id.random();
+        DynamicServiceAnnouncement redStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "1"));
+        DynamicServiceAnnouncement redWeb = new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("key", "2"));
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", of(redStorage, redWeb));
+
+        Id<Node> greenNodeId = Id.random();
+        DynamicServiceAnnouncement greenStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "3"));
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", of(greenStorage));
+
+        Id<Node> blueNodeId = Id.random();
+        DynamicServiceAnnouncement blueStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "4"));
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", of(blueStorage));
+
+        dynamicStore.put(redNodeId, red);
+        dynamicStore.put(greenNodeId, green);
+        dynamicStore.put(blueNodeId, blue);
+
+        assertEquals(resource.getServices(), new Services("testing", ImmutableSet.of(
+                toServiceWith(redNodeId, red.getLocation(), red.getPool()).apply(redStorage),
+                toServiceWith(redNodeId, red.getLocation(), red.getPool()).apply(redWeb),
+                toServiceWith(greenNodeId, green.getLocation(), green.getPool()).apply(greenStorage),
+                toServiceWith(blueNodeId, blue.getLocation(), blue.getPool()).apply(blueStorage))));
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestServiceResource.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestServiceResource.java
@@ -24,7 +24,6 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 
 import static com.facebook.airlift.discovery.server.DynamicServiceAnnouncement.toServiceWith;
-import static com.google.common.collect.ImmutableSet.of;
 import static org.testng.Assert.assertEquals;
 
 public class TestServiceResource
@@ -43,23 +42,23 @@ public class TestServiceResource
     public void testGetByType()
     {
         Id<Node> redNodeId = Id.random();
-        DynamicServiceAnnouncement redStorage = new DynamicServiceAnnouncement(Id.<Service>random() , "storage", ImmutableMap.of("key", "1"));
+        DynamicServiceAnnouncement redStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "1"));
         DynamicServiceAnnouncement redWeb = new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("key", "2"));
-        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", of(redStorage, redWeb));
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(redStorage, redWeb));
 
         Id<Node> greenNodeId = Id.random();
         DynamicServiceAnnouncement greenStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "3"));
-        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", of(greenStorage));
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", ImmutableSet.of(greenStorage));
 
         Id<Node> blueNodeId = Id.random();
         DynamicServiceAnnouncement blueStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "4"));
-        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", of(blueStorage));
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", ImmutableSet.of(blueStorage));
 
         dynamicStore.put(redNodeId, red);
         dynamicStore.put(greenNodeId, green);
         dynamicStore.put(blueNodeId, blue);
 
-        assertEquals(resource.getServices("storage"), new Services("testing", of(
+        assertEquals(resource.getServices("storage"), new Services("testing", ImmutableSet.of(
                 toServiceWith(redNodeId, red.getLocation(), red.getPool()).apply(redStorage),
                 toServiceWith(greenNodeId, green.getLocation(), green.getPool()).apply(greenStorage),
                 toServiceWith(blueNodeId, blue.getLocation(), blue.getPool()).apply(blueStorage))));
@@ -76,15 +75,15 @@ public class TestServiceResource
         Id<Node> redNodeId = Id.random();
         DynamicServiceAnnouncement redStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "1"));
         DynamicServiceAnnouncement redWeb = new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("key", "2"));
-        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", of(redStorage, redWeb));
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(redStorage, redWeb));
 
         Id<Node> greenNodeId = Id.random();
         DynamicServiceAnnouncement greenStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "3"));
-        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", of(greenStorage));
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", ImmutableSet.of(greenStorage));
 
         Id<Node> blueNodeId = Id.random();
         DynamicServiceAnnouncement blueStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "4"));
-        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", of(blueStorage));
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", ImmutableSet.of(blueStorage));
 
         dynamicStore.put(redNodeId, red);
         dynamicStore.put(greenNodeId, green);
@@ -105,15 +104,15 @@ public class TestServiceResource
         Id<Node> redNodeId = Id.random();
         DynamicServiceAnnouncement redStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "1"));
         DynamicServiceAnnouncement redWeb = new DynamicServiceAnnouncement(Id.<Service>random(), "web", ImmutableMap.of("key", "2"));
-        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", of(redStorage, redWeb));
+        DynamicAnnouncement red = new DynamicAnnouncement("testing", "alpha", "/a/b/c", ImmutableSet.of(redStorage, redWeb));
 
         Id<Node> greenNodeId = Id.random();
         DynamicServiceAnnouncement greenStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "3"));
-        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", of(greenStorage));
+        DynamicAnnouncement green = new DynamicAnnouncement("testing", "alpha", "/x/y/z", ImmutableSet.of(greenStorage));
 
         Id<Node> blueNodeId = Id.random();
         DynamicServiceAnnouncement blueStorage = new DynamicServiceAnnouncement(Id.<Service>random(), "storage", ImmutableMap.of("key", "4"));
-        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", of(blueStorage));
+        DynamicAnnouncement blue = new DynamicAnnouncement("testing", "beta", "/a/b/c", ImmutableSet.of(blueStorage));
 
         dynamicStore.put(redNodeId, red);
         dynamicStore.put(greenNodeId, green);

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestServices.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestServices.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.io.Resources;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.testing.Assertions.assertNotEquals;
+import static org.testng.Assert.assertEquals;
+
+public class TestServices
+{
+    @Test
+    public void testCreatesDefensiveCopyOfServices()
+    {
+        Set<Service> set = Sets.newHashSet();
+        set.add(new Service(Id.<Service>random(), Id.<Node>random(), "blue", "pool", "/location", ImmutableMap.of("key", "value")));
+
+        Services services = new Services("testing", set);
+        assertEquals(services.getServices(), set);
+
+        set.add(new Service(Id.<Service>random(), Id.<Node>random(), "red", "pool", "/location", ImmutableMap.of("key", "value")));
+        assertNotEquals(services.getServices(), set);
+    }
+
+    @Test
+    public void testServicesSetIsImmutable()
+    {
+        Service blue = new Service(Id.<Service>random(), Id.<Node>random(), "blue", "pool", "/location", ImmutableMap.of("key", "value"));
+
+        Services services = new Services("testing", Sets.newHashSet(blue));
+        try {
+            services.getServices().add(new Service(Id.<Service>random(), Id.<Node>random(), "red", "pool", "/location", ImmutableMap.of("key", "value")));
+
+            // a copy of the internal map is acceptable
+            assertEquals(services.getServices(), ImmutableSet.of(blue));
+        }
+        catch (UnsupportedOperationException e) {
+            // an exception is ok, too
+        }
+    }
+
+    @Test
+    public void testToJson()
+            throws IOException
+    {
+        Service blue = new Service(Id.<Service>valueOf("c0c5be5f-b298-4cfa-922a-3e5954208444"), Id.<Node>valueOf("3ff52f57-04e0-46c3-b606-7497b09dd5c7"), "blue", "poolA", "/locationA", ImmutableMap.of("key", "valueA"));
+        Service red = new Service(Id.<Service>valueOf("e3780aba-98fe-4de1-b682-5cd7a3264367"), Id.<Node>valueOf("989c4a90-ef68-4a05-8ad9-73a02aea406c"), "red", "poolB", "/locationB", ImmutableMap.of("key", "valueB"));
+        Services services = new Services("testing", ImmutableSet.of(blue, red));
+
+        String json = jsonCodec(Services.class).toJson(services);
+
+        JsonCodec<Object> codec = jsonCodec(Object.class);
+        Object parsed = codec.fromJson(json);
+        Object expected = codec.fromJson(Resources.toString(Resources.getResource("services.json"), Charsets.UTF_8));
+
+        assertEquals(parsed, expected);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "environment.*")
+    public void testValidatesEnvironmentNotNull()
+    {
+        new Services(null, Collections.<Service>emptySet());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "services.*")
+    public void testValidatesServicesNotNull()
+    {
+        new Services("testing", null);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestServices.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestServices.java
@@ -16,7 +16,6 @@
 package com.facebook.airlift.discovery.server;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -24,7 +23,9 @@ import com.google.common.io.Resources;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
@@ -36,7 +37,7 @@ public class TestServices
     @Test
     public void testCreatesDefensiveCopyOfServices()
     {
-        Set<Service> set = Sets.newHashSet();
+        Set<Service> set = new HashSet<>();
         set.add(new Service(Id.<Service>random(), Id.<Node>random(), "blue", "pool", "/location", ImmutableMap.of("key", "value")));
 
         Services services = new Services("testing", set);
@@ -75,7 +76,7 @@ public class TestServices
 
         JsonCodec<Object> codec = jsonCodec(Object.class);
         Object parsed = codec.fromJson(json);
-        Object expected = codec.fromJson(Resources.toString(Resources.getResource("services.json"), Charsets.UTF_8));
+        Object expected = codec.fromJson(Resources.toString(Resources.getResource("services.json"), StandardCharsets.UTF_8));
 
         assertEquals(parsed, expected);
     }

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticAnnouncement.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.io.Resources;
+import org.testng.annotations.Test;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.facebook.airlift.testing.Assertions.assertNotEquals;
+import static com.facebook.airlift.testing.EquivalenceTester.equivalenceTester;
+import static com.facebook.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static org.testng.Assert.assertEquals;
+
+public class TestStaticAnnouncement
+{
+    @Test
+    public void testValidatesNullEnvironment()
+    {
+        StaticAnnouncement announcement = new StaticAnnouncement(null, "type", "pool", "location", Collections.<String, String>emptyMap());
+        assertFailsValidation(announcement, "environment", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testValidatesNullType()
+    {
+        StaticAnnouncement announcement = new StaticAnnouncement("environment", null, "pool", "location", Collections.<String, String>emptyMap());
+        assertFailsValidation(announcement, "type", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testValidatesNullPool()
+    {
+        StaticAnnouncement announcement = new StaticAnnouncement("environment", "type", null, "location", Collections.<String, String>emptyMap());
+        assertFailsValidation(announcement, "pool", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testValidatesNullProperties()
+    {
+        StaticAnnouncement announcement = new StaticAnnouncement("environment", "type", "pool", "location", null);
+        assertFailsValidation(announcement, "properties", "may not be null", NotNull.class);
+    }
+
+    @Test
+    public void testParsing()
+            throws IOException
+    {
+        JsonCodec<StaticAnnouncement> codec = JsonCodec.jsonCodec(StaticAnnouncement.class);
+
+        StaticAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("static-announcement.json"), Charsets.UTF_8));
+        StaticAnnouncement expected = new StaticAnnouncement("testing", "blue", "poolA", "/a/b/c", ImmutableMap.of("key", "valueA"));
+
+        assertEquals(parsed, expected);
+    }
+
+    @Test
+    public void testEquivalence()
+    {
+        equivalenceTester()
+                // vary fields, one by one
+                .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueB")),
+                                    new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueB")))
+                .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolB", "/a/b", ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement("testing", "blue", "poolB", "/a/b", ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new StaticAnnouncement("testing", "red", "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement("testing", "red", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new StaticAnnouncement("testing", "red", "poolA", "/x/y", ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement("testing", "red", "poolA", "/x/y", ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new StaticAnnouncement("production", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement("production", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                        // null fields
+                .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", "/a/b", null),
+                                    new StaticAnnouncement("testing", "blue", "poolA", "/a/b", null))
+                .addEquivalentGroup(new StaticAnnouncement("testing", "blue", null, "/a/b", ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement("testing", "blue", null, "/a/b", ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new StaticAnnouncement("testing", null, "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement("testing", null, "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", null, ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement("testing", "blue", "poolA", null, ImmutableMap.of("key", "valueA")))
+                .addEquivalentGroup(new StaticAnnouncement(null, "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
+                                    new StaticAnnouncement(null, "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+
+                        // empty properties
+                .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", "/a/b", Collections.<String, String>emptyMap()),
+                                    new StaticAnnouncement("testing", "blue", "poolA", "/a/b", Collections.<String, String>emptyMap()))
+                .check();
+    }
+
+    @Test
+    public void testCreatesDefensiveCopyOfProperties()
+    {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("key", "value");
+        StaticAnnouncement announcement = new StaticAnnouncement("testing", "type", "pool", "/a/b", properties);
+
+        assertEquals(announcement.getProperties(), properties);
+        properties.put("key2", "value2");
+        assertNotEquals(announcement.getProperties(), properties);
+    }
+
+    @Test
+    public void testImmutableProperties()
+    {
+        StaticAnnouncement announcement = new StaticAnnouncement("testing", "type", "pool", "/a/b", ImmutableMap.of("key", "value"));
+
+        try {
+            announcement.getProperties().put("key2", "value2");
+
+            // a copy of the internal map is acceptable
+            assertEquals(announcement.getProperties(), ImmutableMap.of("key", "value"));
+        }
+        catch (UnsupportedOperationException e) {
+            // an exception is ok, too
+        }
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticAnnouncement.java
@@ -81,32 +81,32 @@ public class TestStaticAnnouncement
         equivalenceTester()
                 // vary fields, one by one
                 .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                        new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueB")),
-                                    new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueB")))
+                        new StaticAnnouncement("testing", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueB")))
                 .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolB", "/a/b", ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement("testing", "blue", "poolB", "/a/b", ImmutableMap.of("key", "valueA")))
+                        new StaticAnnouncement("testing", "blue", "poolB", "/a/b", ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new StaticAnnouncement("testing", "red", "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement("testing", "red", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                        new StaticAnnouncement("testing", "red", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new StaticAnnouncement("testing", "red", "poolA", "/x/y", ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement("testing", "red", "poolA", "/x/y", ImmutableMap.of("key", "valueA")))
+                        new StaticAnnouncement("testing", "red", "poolA", "/x/y", ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new StaticAnnouncement("production", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement("production", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
-                        // null fields
+                        new StaticAnnouncement("production", "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                // null fields
                 .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", "/a/b", null),
-                                    new StaticAnnouncement("testing", "blue", "poolA", "/a/b", null))
+                        new StaticAnnouncement("testing", "blue", "poolA", "/a/b", null))
                 .addEquivalentGroup(new StaticAnnouncement("testing", "blue", null, "/a/b", ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement("testing", "blue", null, "/a/b", ImmutableMap.of("key", "valueA")))
+                        new StaticAnnouncement("testing", "blue", null, "/a/b", ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new StaticAnnouncement("testing", null, "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement("testing", null, "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                        new StaticAnnouncement("testing", null, "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", null, ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement("testing", "blue", "poolA", null, ImmutableMap.of("key", "valueA")))
+                        new StaticAnnouncement("testing", "blue", "poolA", null, ImmutableMap.of("key", "valueA")))
                 .addEquivalentGroup(new StaticAnnouncement(null, "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")),
-                                    new StaticAnnouncement(null, "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
+                        new StaticAnnouncement(null, "blue", "poolA", "/a/b", ImmutableMap.of("key", "valueA")))
 
-                        // empty properties
+                // empty properties
                 .addEquivalentGroup(new StaticAnnouncement("testing", "blue", "poolA", "/a/b", Collections.<String, String>emptyMap()),
-                                    new StaticAnnouncement("testing", "blue", "poolA", "/a/b", Collections.<String, String>emptyMap()))
+                        new StaticAnnouncement("testing", "blue", "poolA", "/a/b", Collections.<String, String>emptyMap()))
                 .check();
     }
 

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticAnnouncement.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticAnnouncement.java
@@ -16,16 +16,16 @@
 package com.facebook.airlift.discovery.server;
 
 import com.facebook.airlift.json.JsonCodec;
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import org.testng.annotations.Test;
 
 import javax.validation.constraints.NotNull;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.facebook.airlift.testing.Assertions.assertNotEquals;
@@ -69,7 +69,7 @@ public class TestStaticAnnouncement
     {
         JsonCodec<StaticAnnouncement> codec = JsonCodec.jsonCodec(StaticAnnouncement.class);
 
-        StaticAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("static-announcement.json"), Charsets.UTF_8));
+        StaticAnnouncement parsed = codec.fromJson(Resources.toString(Resources.getResource("static-announcement.json"), StandardCharsets.UTF_8));
         StaticAnnouncement expected = new StaticAnnouncement("testing", "blue", "poolA", "/a/b/c", ImmutableMap.of("key", "valueA"));
 
         assertEquals(parsed, expected);
@@ -113,7 +113,7 @@ public class TestStaticAnnouncement
     @Test
     public void testCreatesDefensiveCopyOfProperties()
     {
-        Map<String, String> properties = Maps.newHashMap();
+        Map<String, String> properties = new HashMap<>();
         properties.put("key", "value");
         StaticAnnouncement announcement = new StaticAnnouncement("testing", "type", "pool", "/a/b", properties);
 

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticAnnouncementResource.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticAnnouncementResource.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.jaxrs.testing.MockUriInfo;
+import com.facebook.airlift.node.NodeInfo;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+
+import java.net.URI;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestStaticAnnouncementResource
+{
+    private InMemoryStaticStore store;
+    private StaticAnnouncementResource resource;
+
+    @BeforeMethod
+    public void setup()
+    {
+        store = new InMemoryStaticStore();
+        resource = new StaticAnnouncementResource(store, new NodeInfo("testing"));
+    }
+
+    @Test
+    public void testPost()
+    {
+        StaticAnnouncement announcement = new StaticAnnouncement("testing", "storage", "alpha", "/a/b", ImmutableMap.of("http", "http://localhost:1111"));
+
+        Response response = resource.post(announcement, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/static")));
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode());
+
+        assertEquals(store.getAll().size(), 1);
+        Service service = store.getAll().iterator().next();
+
+        assertNotNull(service.getId());
+        assertNull(service.getNodeId());
+        assertEquals(service.getLocation(), announcement.getLocation());
+        assertEquals(service.getType(), announcement.getType());
+        assertEquals(service.getPool(), announcement.getPool());
+        assertEquals(service.getProperties(), announcement.getProperties());
+    }
+
+    @Test
+    public void testEnvironmentConflict()
+    {
+        StaticAnnouncement announcement = new StaticAnnouncement("production", "storage", "alpha", "/a/b/c", ImmutableMap.of("http", "http://localhost:1111"));
+
+        Response response = resource.post(announcement, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/static")));
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+
+        assertTrue(store.getAll().isEmpty());
+    }
+
+    @Test
+    public void testDelete()
+    {
+        Service blue = new Service(Id.<Service>random(), null, "storage", "alpha", "/a/b/c", ImmutableMap.of("key", "valueBlue"));
+        Service red = new Service(Id.<Service>random(), null, "storage", "alpha", "/a/b/c", ImmutableMap.of("key", "valueRed"));
+
+        store.put(red);
+        store.put(blue);
+
+        resource.delete(blue.getId());
+        assertEquals(store.getAll(), ImmutableSet.of(red));
+    }
+
+    @Test
+    public void testMakesUpLocation()
+    {
+        StaticAnnouncement announcement = new StaticAnnouncement("testing", "storage", "alpha", null, ImmutableMap.of("http", "http://localhost:1111"));
+
+        Response response = resource.post(announcement, new MockUriInfo(URI.create("http://localhost:8080/v1/announcement/")));
+
+        assertNotNull(response);
+        assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode());
+
+        assertEquals(store.getAll().size(), 1);
+        Service service = store.getAll().iterator().next();
+        assertEquals(service.getId(), service.getId());
+        assertNotNull(service.getLocation());
+    }
+
+    @Test
+    public void testGet()
+    {
+        Service blue = new Service(Id.<Service>random(), null, "storage", "alpha", "/a/b/c", ImmutableMap.of("key", "valueBlue"));
+        Service red = new Service(Id.<Service>random(), null, "storage", "alpha", "/a/b/c", ImmutableMap.of("key", "valueRed"));
+
+        store.put(red);
+        store.put(blue);
+
+        Services actual = resource.get();
+        Services expected = new Services("testing", ImmutableSet.of(red, blue));
+
+        assertEquals(actual, expected);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticStore.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.joda.time.DateTime;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.facebook.airlift.testing.Assertions.assertEqualsIgnoreOrder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public abstract class TestStaticStore
+{
+    private static final Service BLUE = new Service(Id.<Service>random(), null, "storage", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableMap.of("http", "http://localhost:1111"));
+    private static final Service RED = new Service(Id.<Service>random(), null, "storage", "poolB", "/US/West/SC4/rack1/host1/vm1/slot2", ImmutableMap.of("http", "http://localhost:2222"));
+    private static final Service GREEN = new Service(Id.<Service>random(), null, "monitoring", "poolA", "/US/West/SC4/rack1/host1/vm1/slot3", ImmutableMap.of("http", "http://localhost:3333"));
+    private static final Service YELLOW = new Service(Id.<Service>random(), null, "storage", "poolB", "/US/West/SC4/rack1/host1/vm1/slot3", ImmutableMap.of("http", "http://localhost:4444"));
+
+    protected StaticStore store;
+    protected TestingTimeSupplier currentTime;
+
+    protected abstract StaticStore initializeStore(Supplier<DateTime> timeSupplier);
+
+    @BeforeMethod
+    public void setup()
+    {
+        currentTime = new TestingTimeSupplier();
+        store = initializeStore(currentTime);
+    }
+
+    @Test
+    public void testEmpty()
+    {
+        assertTrue(store.getAll().isEmpty(), "store should be empty");
+    }
+
+    @Test
+    public void testPutSingle()
+    {
+        store.put(BLUE);
+        assertEquals(store.getAll(), ImmutableSet.of(BLUE));
+    }
+
+    @Test
+    public void testPutMultiple()
+    {
+        store.put(BLUE);
+        store.put(RED);
+        store.put(GREEN);
+
+        assertEqualsIgnoreOrder(store.getAll(), ImmutableSet.of(BLUE, RED, GREEN));
+    }
+
+    @Test
+    public void testGetByType()
+    {
+        store.put(BLUE);
+        store.put(RED);
+        store.put(GREEN);
+
+        assertEqualsIgnoreOrder(store.get("storage"), ImmutableSet.of(BLUE, RED));
+        assertEqualsIgnoreOrder(store.get("monitoring"), ImmutableSet.of(GREEN));
+    }
+
+    @Test
+    public void testGetByTypeAndPool()
+    {
+        store.put(BLUE);
+        store.put(RED);
+        store.put(GREEN);
+        store.put(YELLOW);
+
+        assertEqualsIgnoreOrder(store.get("storage", "poolA"), ImmutableSet.of(BLUE));
+        assertEqualsIgnoreOrder(store.get("monitoring", "poolA"), ImmutableSet.of(GREEN));
+        assertEqualsIgnoreOrder(store.get("storage", "poolB"), ImmutableSet.of(RED, YELLOW));
+    }
+
+    @Test
+    public void testDelete()
+    {
+        store.put(BLUE);
+        store.put(RED);
+        store.put(GREEN);
+
+        assertEqualsIgnoreOrder(store.getAll(), ImmutableSet.of(BLUE, RED, GREEN));
+
+        currentTime.increment();
+
+        store.delete(GREEN.getId());
+
+        assertEqualsIgnoreOrder(store.getAll(), ImmutableSet.of(BLUE, RED));
+        assertTrue(store.get("web").isEmpty());
+        assertTrue(store.get("web", "poolA").isEmpty());
+    }
+
+    @Test
+    public void testCanHandleLotsOfServices()
+    {
+        ImmutableSet.Builder<Service> builder = ImmutableSet.builder();
+        for (int i = 0; i < 5000; ++i) {
+            builder.add(new Service(Id.<Service>random(), null, "storage", "poolA", "/US/West/SC4/rack1/host1/vm1/slot1", ImmutableMap.of("http", "http://localhost:1111")));
+        }
+        Set<Service> services = builder.build();
+
+        for (Service service : services) {
+            store.put(service);
+        }
+
+        assertEquals(store.getAll(), services);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestStaticStore.java
@@ -15,14 +15,14 @@
  */
 package com.facebook.airlift.discovery.server;
 
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.joda.time.DateTime;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.time.ZonedDateTime;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static com.facebook.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static org.testng.Assert.assertEquals;
@@ -38,7 +38,7 @@ public abstract class TestStaticStore
     protected StaticStore store;
     protected TestingTimeSupplier currentTime;
 
-    protected abstract StaticStore initializeStore(Supplier<DateTime> timeSupplier);
+    protected abstract StaticStore initializeStore(Supplier<ZonedDateTime> timeSupplier);
 
     @BeforeMethod
     public void setup()

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestingTimeSupplier.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestingTimeSupplier.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.google.common.base.Supplier;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+class TestingTimeSupplier
+        implements Supplier<DateTime>
+{
+    private final AtomicLong currentTime = new AtomicLong(System.currentTimeMillis());
+
+    public void add(Duration interval)
+    {
+        currentTime.addAndGet(interval.toMillis());
+    }
+
+    public void set(DateTime currentTime)
+    {
+        this.currentTime.set(currentTime.getMillis());
+    }
+
+    public void increment()
+    {
+        currentTime.incrementAndGet();
+    }
+
+    @Override
+    public DateTime get()
+    {
+        return new DateTime(currentTime.get());
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestingTimeSupplier.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestingTimeSupplier.java
@@ -15,7 +15,7 @@
  */
 package com.facebook.airlift.discovery.server;
 
-import io.airlift.units.Duration;
+import com.facebook.airlift.units.Duration;
 import org.joda.time.DateTime;
 
 import java.time.Instant;

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestingTimeSupplier.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestingTimeSupplier.java
@@ -15,14 +15,17 @@
  */
 package com.facebook.airlift.discovery.server;
 
-import com.google.common.base.Supplier;
 import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
-class TestingTimeSupplier
-        implements Supplier<DateTime>
+public class TestingTimeSupplier
+        implements Supplier<ZonedDateTime>
 {
     private final AtomicLong currentTime = new AtomicLong(System.currentTimeMillis());
 
@@ -42,8 +45,8 @@ class TestingTimeSupplier
     }
 
     @Override
-    public DateTime get()
+    public ZonedDateTime get()
     {
-        return new DateTime(currentTime.get());
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(currentTime.get()), TimeZone.getDefault().toZoneId());
     }
 }

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/testing/TestTestingDiscoveryServer.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/testing/TestTestingDiscoveryServer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server.testing;
+
+import com.facebook.airlift.discovery.client.Announcement;
+import com.facebook.airlift.discovery.client.DiscoveryAnnouncementClient;
+import com.facebook.airlift.discovery.client.DiscoveryLookupClient;
+import com.facebook.airlift.discovery.client.HttpDiscoveryAnnouncementClient;
+import com.facebook.airlift.discovery.client.HttpDiscoveryLookupClient;
+import com.facebook.airlift.discovery.client.ServiceDescriptors;
+import com.facebook.airlift.discovery.client.ServiceDescriptorsRepresentation;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.airlift.node.NodeInfo;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static org.testng.Assert.assertEquals;
+
+public class TestTestingDiscoveryServer
+{
+    private static final String ENVIRONMENT = "testing";
+    private static final String SERVICE = "taco";
+
+    @Test(timeOut = 30_000)
+    public void testServer()
+            throws Exception
+    {
+        try (TestingDiscoveryServer server = new TestingDiscoveryServer(ENVIRONMENT);
+                HttpClient httpClient = new JettyHttpClient()) {
+            DiscoveryLookupClient lookup = new HttpDiscoveryLookupClient(
+                    server::getBaseUrl,
+                    new NodeInfo(ENVIRONMENT),
+                    jsonCodec(ServiceDescriptorsRepresentation.class),
+                    httpClient);
+
+            DiscoveryAnnouncementClient announcement = new HttpDiscoveryAnnouncementClient(
+                    server::getBaseUrl,
+                    new NodeInfo(ENVIRONMENT),
+                    jsonCodec(Announcement.class),
+                    httpClient);
+
+            ServiceDescriptors response = lookup.getServices(SERVICE).get();
+            assertEquals(response.getServiceDescriptors().size(), 0);
+
+            announcement.announce(ImmutableSet.of(serviceAnnouncement(SERVICE).build())).get();
+
+            response = lookup.getServices(SERVICE).get();
+            assertEquals(response.getServiceDescriptors().size(), 1);
+
+            announcement.unannounce().get();
+
+            response = lookup.getServices(SERVICE).get();
+            assertEquals(response.getServiceDescriptors().size(), 0);
+        }
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/store/TestEntry.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/store/TestEntry.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.facebook.airlift.json.JsonCodec;
+import org.testng.annotations.Test;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+
+public class TestEntry
+{
+    @Test
+    public void testEntry()
+    {
+        Entry entry = entryOf("fruit", "apple", 123, 456);
+
+        assertEquals(entry.getKey(), "fruit".getBytes(UTF_8));
+        assertEquals(entry.getValue(), "apple".getBytes(UTF_8));
+        assertEquals(entry.getVersion().getSequence(), 123);
+        assertEquals(entry.getTimestamp(), 456);
+        assertEquals(entry.getMaxAgeInMs(), null);
+    }
+
+    @Test
+    public void testSerialization()
+            throws Exception
+    {
+        JsonCodec<Entry> codec = jsonCodec(Entry.class);
+
+        Entry expected = entryOf("fruit", "apple", 123, 456);
+        Entry actual = codec.fromJson(codec.toJsonBytes(expected));
+
+        assertEquals(actual, expected);
+    }
+
+    private static Entry entryOf(String key, String value, long version, long timestamp)
+    {
+        return new Entry(key.getBytes(UTF_8), value.getBytes(UTF_8), new Version(version), timestamp, null);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/store/TestInMemoryStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/store/TestInMemoryStore.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.store;
+
+import com.google.common.base.Charsets;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestInMemoryStore
+{
+    private LocalStore store;
+
+    @BeforeMethod
+    protected void setUp()
+            throws Exception
+    {
+        store = new InMemoryStore(new ConflictResolver());
+    }
+
+    @Test
+    public void testPut()
+    {
+        Entry entry = entryOf("blue", "apple", 1, 0);
+        store.put(entry);
+
+        assertEquals(store.get("blue".getBytes(Charsets.UTF_8)), entry);
+    }
+
+    @Test
+    public void testDelete()
+    {
+        byte[] key = "blue".getBytes(Charsets.UTF_8);
+        Entry entry = entryOf("blue", "apple", 1, 0);
+        store.put(entry);
+
+        store.delete(key, entry.getVersion());
+
+        assertNull(store.get(key));
+    }
+
+    @Test
+    public void testDeleteOlderVersion()
+    {
+        byte[] key = "blue".getBytes(Charsets.UTF_8);
+        Entry entry = entryOf("blue", "apple", 5, 0);
+        store.put(entry);
+
+        store.delete(key, new Version(2));
+
+        assertEquals(store.get("blue".getBytes(Charsets.UTF_8)), entry);
+    }
+
+    @Test
+    public void testResolvesConflict()
+    {
+        Entry entry2 = entryOf("blue", "apple", 2, 0);
+        store.put(entry2);
+
+        Entry entry1 = entryOf("blue", "banana", 1, 0);
+        store.put(entry1);
+
+        assertEquals(store.get("blue".getBytes(Charsets.UTF_8)), entry2);
+    }
+
+    private static Entry entryOf(String key, String value, long version, long timestamp)
+    {
+        return new Entry(key.getBytes(UTF_8), value.getBytes(Charsets.UTF_8), new Version(version), timestamp, null);
+    }
+}

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/store/TestInMemoryStore.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/store/TestInMemoryStore.java
@@ -15,11 +15,10 @@
  */
 package com.facebook.airlift.discovery.store;
 
-import com.google.common.base.Charsets;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static com.google.common.base.Charsets.UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -40,13 +39,13 @@ public class TestInMemoryStore
         Entry entry = entryOf("blue", "apple", 1, 0);
         store.put(entry);
 
-        assertEquals(store.get("blue".getBytes(Charsets.UTF_8)), entry);
+        assertEquals(store.get("blue".getBytes(UTF_8)), entry);
     }
 
     @Test
     public void testDelete()
     {
-        byte[] key = "blue".getBytes(Charsets.UTF_8);
+        byte[] key = "blue".getBytes(UTF_8);
         Entry entry = entryOf("blue", "apple", 1, 0);
         store.put(entry);
 
@@ -58,13 +57,13 @@ public class TestInMemoryStore
     @Test
     public void testDeleteOlderVersion()
     {
-        byte[] key = "blue".getBytes(Charsets.UTF_8);
+        byte[] key = "blue".getBytes(UTF_8);
         Entry entry = entryOf("blue", "apple", 5, 0);
         store.put(entry);
 
         store.delete(key, new Version(2));
 
-        assertEquals(store.get("blue".getBytes(Charsets.UTF_8)), entry);
+        assertEquals(store.get("blue".getBytes(UTF_8)), entry);
     }
 
     @Test
@@ -76,11 +75,11 @@ public class TestInMemoryStore
         Entry entry1 = entryOf("blue", "banana", 1, 0);
         store.put(entry1);
 
-        assertEquals(store.get("blue".getBytes(Charsets.UTF_8)), entry2);
+        assertEquals(store.get("blue".getBytes(UTF_8)), entry2);
     }
 
     private static Entry entryOf(String key, String value, long version, long timestamp)
     {
-        return new Entry(key.getBytes(UTF_8), value.getBytes(Charsets.UTF_8), new Version(version), timestamp, null);
+        return new Entry(key.getBytes(UTF_8), value.getBytes(UTF_8), new Version(version), timestamp, null);
     }
 }

--- a/discovery-server/src/test/resources/announcement.json
+++ b/discovery-server/src/test/resources/announcement.json
@@ -1,0 +1,21 @@
+{
+    "environment": "testing",
+    "location": "/a/b/c",
+    "pool": "poolA",
+    "services": [
+        {
+            "id": "1c001650-7841-11e0-a1f0-0800200c9a66",
+            "type": "red",
+            "properties": {
+                "key" : "redValue"
+            }
+        },
+        {
+            "id": "2a817750-7841-11e0-a1f0-0800200c9a66",
+            "type": "blue",
+            "properties": {
+                "key" : "blueValue"
+            }
+        }
+    ]
+}

--- a/discovery-server/src/test/resources/dynamic-announcement.json
+++ b/discovery-server/src/test/resources/dynamic-announcement.json
@@ -1,0 +1,7 @@
+{
+    "id": "ff824508-b6a6-4dfc-8f0b-85028465534d",
+    "type": "blue",
+    "properties": {
+        "key": "valueA"
+    }
+}

--- a/discovery-server/src/test/resources/service.json
+++ b/discovery-server/src/test/resources/service.json
@@ -1,0 +1,10 @@
+{
+    "id" : "c0c5be5f-b298-4cfa-922a-3e5954208444",
+    "nodeId" : "3ff52f57-04e0-46c3-b606-7497b09dd5c7",
+    "type" : "type",
+    "pool" : "pool",
+    "location" : "/location",
+    "properties" : {
+        "key" : "value"
+    }
+}

--- a/discovery-server/src/test/resources/services.json
+++ b/discovery-server/src/test/resources/services.json
@@ -1,0 +1,25 @@
+{
+    "environment" : "testing",
+    "services" : [
+        {
+            "id" : "c0c5be5f-b298-4cfa-922a-3e5954208444",
+            "nodeId" : "3ff52f57-04e0-46c3-b606-7497b09dd5c7",
+            "type" : "blue",
+            "pool" : "poolA",
+            "location" : "/locationA",
+            "properties" : {
+                "key" : "valueA"
+            }
+        },
+        {
+            "id" : "e3780aba-98fe-4de1-b682-5cd7a3264367",
+            "nodeId" : "989c4a90-ef68-4a05-8ad9-73a02aea406c",
+            "type" : "red",
+            "pool" : "poolB",
+            "location" : "/locationB",
+            "properties" : {
+                "key" : "valueB"
+            }
+        }
+    ]
+}

--- a/discovery-server/src/test/resources/static-announcement.json
+++ b/discovery-server/src/test/resources/static-announcement.json
@@ -1,0 +1,9 @@
+{
+    "environment": "testing",
+    "location": "/a/b/c",
+    "type": "blue",
+    "pool": "poolA",
+    "properties": {
+        "key": "valueA"
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <module>http-utils</module>
         <module>dbpool</module>
         <module>discovery</module>
+        <module>discovery-server</module>
         <module>event</module>
         <module>http-client</module>
         <module>http-server</module>
@@ -123,6 +124,12 @@
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>discovery</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.airlift</groupId>
+                <artifactId>discovery-server</artifactId>
                 <version>${dep.airlift.version}</version>
             </dependency>
 

--- a/units/pom.xml
+++ b/units/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>units</artifactId>
-    <version>0.216-SNAPSHOT</version>
+    <version>0.217-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>units</name>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airlift</artifactId>
-        <version>0.216-SNAPSHOT</version>
+        <version>0.217-SNAPSHOT</version>
     </parent>
 
     <inceptionYear>2016</inceptionYear>


### PR DESCRIPTION
_Clone of https://github.com/prestodb/airlift/pull/101_

This PR adds the discovery server from https://github.com/prestodb/discovery.

The change is split into a few commits

1. Copies all the existing code for the discovery-server module file-for-file directly into the airlift repository
1. Updates the airlift pom and discovery server pom with necessary changes to facilitate the build
a. This intentionally changes the maven groupId from com.facebook.airlift.discovery to com.facebook.airlift to comply with the pattern that the rest of the modules in this project follow.
1. Fixes checkstyle issues where the old project did not comply
1. Changes from the modernizer plugin to comply and pass tests.