### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Publish release
+
+on:
+  workflow_dispatch:
+
+env:
+  JAVA_VERSION: ${{ vars.JAVA_VERSION }}
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION }}
+  MAVEN_OPTS: ${{ vars.MAVEN_OPTS }}
+  GPG_KEY_FILE: /tmp/gpg-key.txt
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    environment: release
+    strategy:
+      fail-fast: true
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Check branch
+        if: ${{ github.ref != 'refs/heads/master' }}
+        run: echo "Invalid branch. This action can only be run on the master branch." && exit 1
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRESTODB_CI_TOKEN }}
+          show-progress: false
+          fetch-depth: 0
+          ref: master
+
+      - name: Set up JDK ${{ env.JAVA_DISTRIBUTION }}/${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          overwrite-settings: true
+          server-id: ossrh
+          server-username: NEXUS_USERNAME
+          server-password: NEXUS_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+
+      - name: Set up git
+        run: |
+          git config --global --add safe.directory ${{github.workspace}}
+          git config --global user.email "ci@lists.prestodb.io"
+          git config --global user.name "prestodb-ci"
+          git config --global alias.ls 'log --pretty=format:"%cd %h %ce: %s" --date=short --no-merges'
+          git config pull.rebase false
+
+      - name: Get release version
+        id: get-version
+        run: |
+          RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1 | sed 's/-SNAPSHOT//')
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$RELEASE_VERSION"
+          echo "In case cut release failed, please delete the tag ${RELEASE_VERSION} manually"
+
+      - name: Prepare release
+        run: |
+          git reset --hard
+          mvn release:prepare -B -DreleaseVersion=${{ env.RELEASE_VERSION }} -DskipTests \
+                        -DautoVersionSubmodules=true \
+                        -DgenerateBackupPoms=false
+          grep -m 1 "<version>" pom.xml
+          git ls -5
+
+      - name: Set up GPG key
+        env:
+          GPG_TTY: $(tty)
+        run: |
+          echo "${{ secrets.GPG_SECRET }}" > ${{ env.GPG_KEY_FILE }}
+          chmod 600 ${{ env.GPG_KEY_FILE }}
+          gpg --import --batch ${{ env.GPG_KEY_FILE }}
+          gpg --batch --yes --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" --sign ${{ env.GPG_KEY_FILE }}
+
+      - name: Publish release
+        env:
+          NEXUS_USERNAME: "${{ secrets.NEXUS_USERNAME }}"
+          NEXUS_PASSWORD: "${{ secrets.NEXUS_PASSWORD }}"
+          GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
+        run: |
+          git checkout ${{ env.RELEASE_VERSION }}
+          git ls -5
+          cat ~/.m2/settings.xml
+          mvn -V -B -U -e -T2C deploy \
+            -DautoReleaseAfterClose=true \
+            -DkeepStagingRepositoryOnCloseRuleFailure=true \
+            -DkeepStagingRepositoryOnFailure=true \
+            -DstagingProgressTimeoutMinutes=10 \
+            -DskipTests \
+            -Poss-release \
+            -Pdeploy-to-ossrh
+
+      - name: Push changes and tags
+        run: |
+          git checkout master
+          git ls -5
+          git push origin master --tags

--- a/drift/pom.xml
+++ b/drift/pom.xml
@@ -143,31 +143,31 @@
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>bootstrap</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>configuration</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>concurrent</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>jmx</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>log</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -185,25 +185,25 @@
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>security</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>stats</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>testing</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>units</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <air.java.version>1.8.0-40</air.java.version>
 
         <dep.airlift.version>0.217-SNAPSHOT</dep.airlift.version>
-        <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
+        <dep.packaging.version>${project.version}</dep.packaging.version>
         <dep.jetty.version>12.0.18</dep.jetty.version>
         <dep.jersey.version>4.0.0-M2</dep.jersey.version>
         <dep.drift.version>0.217-SNAPSHOT</dep.drift.version>
@@ -126,97 +126,97 @@
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>bootstrap</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>concurrent</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>http-utils</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>configuration</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>dbpool</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>discovery</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>discovery-server</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>event</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>http-client</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>http-server</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>jaxrs</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>jmx-http-rpc</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>jmx-http</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>jmx</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>units</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>json</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -274,7 +274,7 @@
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>launcher</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
                 <classifier>bin</classifier>
                 <type>tar.gz</type>
             </dependency>
@@ -282,49 +282,49 @@
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>log</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>log-manager</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>node</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>packaging</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>security</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>stats</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>testing</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>com.facebook.airlift</groupId>
                 <artifactId>trace-token</artifactId>
-                <version>${dep.airlift.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Add the release action, configuration:

1. JAVA_VERSION: 17
2. MAVEN_OPTS: `--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED`

Tested with https://github.com/unix280/airlift/actions/runs/14716907941, the failure is as expected since there is no way to test publishing to https://oss.sonatype.org/ without correct token.