### PR TITLE
[drift] Use comma for fields of Enum

### DIFF
--- a/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftIdlRenderer.java
+++ b/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftIdlRenderer.java
@@ -137,7 +137,7 @@ public final class ThriftIdlRenderer
             if (metadata.getByEnumConstant() != null) {
                 builder.append(" = ").append(metadata.getByEnumConstant().get(entry.getKey()));
             }
-            builder.append(";\n");
+            builder.append(",\n");
         }
         return builder.toString();
     }

--- a/drift/drift-idl-generator/src/test/resources/expected/everything.txt
+++ b/drift/drift-idl-generator/src/test/resources/expected/everything.txt
@@ -1,10 +1,10 @@
 include "common/fruit.thrift"
 
 enum Letter {
-  A = 65;
-  B = 66;
-  C = 67;
-  D = 68;
+  A = 65,
+  B = 66,
+  C = 67,
+  D = 68,
 }
 
 struct Bonk {

--- a/drift/drift-idl-generator/src/test/resources/expected/fruit.txt
+++ b/drift/drift-idl-generator/src/test/resources/expected/fruit.txt
@@ -5,15 +5,15 @@ enum Fruit {
   /**
    * Large and sweet
    */
-  APPLE = 2;
+  APPLE = 2,
 
   /**
    * Yellow
    */
-  BANANA = 3;
+  BANANA = 3,
 
   /**
    * Small and tart
    */
-  CHERRY = 5;
+  CHERRY = 5,
 }

--- a/drift/drift-idl-generator/src/test/resources/expected/scribe.txt
+++ b/drift/drift-idl-generator/src/test/resources/expected/scribe.txt
@@ -1,6 +1,6 @@
 enum Result {
-  OK = 0;
-  TRY_LATER = 1;
+  OK = 0,
+  TRY_LATER = 1,
 }
 
 struct DriftLogEntry {


### PR DESCRIPTION
1. we should use coma for fields within enum when generating idl files