### PR TITLE
Fix bad cast in ReplicatedDynamicStore

### DIFF
--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedDynamicStore.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/server/ReplicatedDynamicStore.java
@@ -93,17 +93,12 @@ public class ReplicatedDynamicStore
 
     private Supplier<Set<Service>> servicesSupplier()
     {
-        return new Supplier<Set<Service>>()
-        {
-            @Override
-            public Set<Service> get()
-            {
-                ImmutableSet.Builder<Service> builder = ImmutableSet.builder();
-                for (Entry entry : store.getAll()) {
-                    builder.addAll(codec.fromJson(entry.getValue()));
-                }
-                return builder.build();
+        return () -> {
+            ImmutableSet.Builder<Service> builder = ImmutableSet.builder();
+            for (Entry entry : store.getAll()) {
+                builder.addAll(codec.fromJson(entry.getValue()));
             }
+            return builder.build();
         };
     }
 
@@ -112,6 +107,6 @@ public class ReplicatedDynamicStore
         if (ttl.toMillis() == 0) {
             return supplier;
         }
-        return memoizeWithExpiration((com.google.common.base.Supplier) supplier, ttl.toMillis(), MILLISECONDS);
+        return memoizeWithExpiration(supplier::get, ttl.toMillis(), MILLISECONDS);
     }
 }

--- a/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedDynamicStoreWithTtl.java
+++ b/discovery-server/src/test/java/com/facebook/airlift/discovery/server/TestReplicatedDynamicStoreWithTtl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.airlift.discovery.server;
+
+import com.facebook.airlift.units.Duration;
+
+import java.time.ZonedDateTime;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestReplicatedDynamicStoreWithTtl
+        extends TestReplicatedDynamicStore
+{
+    @Override
+    protected DynamicStore initializeStore(DiscoveryConfig config, Supplier<ZonedDateTime> timeSupplier)
+    {
+        // Tests for initialization of the memoized supplier with Ttl
+        config.setStoreCacheTtl(Duration.succinctDuration(1000, SECONDS));
+        return super.initializeStore(config, timeSupplier);
+    }
+
+    @Override
+    public void testDelete()
+    {
+        // ignore; test relies on not having the cached service supplier
+    }
+}


### PR DESCRIPTION
Missed the change for moving to JVM `Supplier` in the ReplicatedDynamicStore during airlift upgrade