### PR TITLE
[Drift] Add support for Java optional to IDL generator

### DIFF
--- a/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftIdlGenerator.java
+++ b/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftIdlGenerator.java
@@ -22,6 +22,7 @@ import com.facebook.drift.codec.metadata.FieldKind;
 import com.facebook.drift.codec.metadata.MetadataErrorException;
 import com.facebook.drift.codec.metadata.MetadataErrors.Monitor;
 import com.facebook.drift.codec.metadata.MetadataWarningException;
+import com.facebook.drift.codec.metadata.ReflectionHelper;
 import com.facebook.drift.codec.metadata.ThriftCatalog;
 import com.facebook.drift.codec.metadata.ThriftFieldMetadata;
 import com.facebook.drift.codec.metadata.ThriftMethodMetadata;
@@ -35,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -318,6 +320,12 @@ public class ThriftIdlGenerator
     @SuppressFBWarnings("NS_DANGEROUS_NON_SHORT_CIRCUIT")
     private boolean verifyField(ThriftType type)
     {
+        if (ReflectionHelper.isOptional(type.getJavaType())) {
+            Type unwrappedJavaType = ReflectionHelper.getOptionalType(type.getJavaType());
+            ThriftType thriftType = this.codecManager.getCatalog().getThriftType(unwrappedJavaType);
+            return verifyField(thriftType);
+        }
+
         ThriftProtocolType proto = type.getProtocolType();
         if (proto == ThriftProtocolType.SET || proto == ThriftProtocolType.LIST) {
             return verifyElementType(type.getValueTypeReference());

--- a/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftIdlRenderer.java
+++ b/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftIdlRenderer.java
@@ -17,6 +17,7 @@ package com.facebook.drift.idl.generator;
 
 import com.facebook.drift.annotations.ThriftField.Requiredness;
 import com.facebook.drift.codec.ThriftProtocolType;
+import com.facebook.drift.codec.metadata.ReflectionHelper;
 import com.facebook.drift.codec.metadata.ThriftEnumMetadata;
 import com.facebook.drift.codec.metadata.ThriftFieldMetadata;
 import com.facebook.drift.codec.metadata.ThriftMethodMetadata;
@@ -27,6 +28,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -164,7 +166,7 @@ public final class ThriftIdlRenderer
                     .append(documentation(field.getDocumentation(), "  "))
                     .append(format("  %s: %s%s %s;\n",
                             field.getId(),
-                            requiredness(field.getRequiredness()),
+                            requiredness(field),
                             typeName(field.getThriftType()),
                             field.getName()));
         }
@@ -186,8 +188,14 @@ public final class ThriftIdlRenderer
         throw new IllegalArgumentException("Unknown type: " + struct);
     }
 
-    private static String requiredness(Requiredness requiredness)
+    private static String requiredness(ThriftFieldMetadata field)
     {
+        Type type = field.getThriftType().getJavaType();
+        if (ReflectionHelper.isOptional(type)) {
+            return "optional ";
+        }
+
+        Requiredness requiredness = field.getRequiredness();
         switch (requiredness) {
             case REQUIRED:
                 return "required ";

--- a/drift/drift-idl-generator/src/test/java/com/facebook/drift/idl/generator/OptionalField.java
+++ b/drift/drift-idl-generator/src/test/java/com/facebook/drift/idl/generator/OptionalField.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.drift.idl.generator;
+
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
+import java.util.Optional;
+
+import static com.facebook.drift.annotations.ThriftField.Requiredness.OPTIONAL;
+
+@ThriftStruct("OptionalField")
+public class OptionalField
+{
+    @ThriftField(1)
+    public Optional<String> optionalString;
+
+    @ThriftField(value = 2, requiredness = OPTIONAL)
+    public Optional<Long> optionalLong;
+
+    @ThriftField(value = 3, requiredness = OPTIONAL)
+    public Integer optionalInteger;
+}

--- a/drift/drift-idl-generator/src/test/java/com/facebook/drift/idl/generator/TestThriftIdlGenerator.java
+++ b/drift/drift-idl-generator/src/test/java/com/facebook/drift/idl/generator/TestThriftIdlGenerator.java
@@ -39,6 +39,7 @@ public class TestThriftIdlGenerator
         assertGenerated(Fruit.class, "fruit", ignored -> {});
         assertGenerated(URIField.class, "uri", ignored -> {});
         assertGenerated(TreeNode.class, "tree", ignored -> {});
+        assertGenerated(OptionalField.class, "optional", ignored -> {});
 
         assertGenerated(Point.class, "point", config -> config
                 .namespaces(ImmutableMap.<String, String>builder()

--- a/drift/drift-idl-generator/src/test/resources/expected/optional.txt
+++ b/drift/drift-idl-generator/src/test/resources/expected/optional.txt
@@ -1,0 +1,5 @@
+struct OptionalField {
+  1: optional string optionalString;
+  2: optional i64 optionalLong;
+  3: optional i32 optionalInteger;
+}


### PR DESCRIPTION
1. Add support for Java optional to IDL generator
2. Optional field will be marked as optional even without requireness annotation