### PR TITLE
[Drift] Support optional user-defined class while generating idl

### DIFF
--- a/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftIdlGenerator.java
+++ b/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftIdlGenerator.java
@@ -88,7 +88,7 @@ public class ThriftIdlGenerator
     private final Set<ThriftType> customTypes = new HashSet<>();
 
     private Set<ThriftType> knownTypes = new HashSet<>(BUILT_IN_TYPES);
-    private ThriftTypeRenderer typeRenderer = new ThriftTypeRenderer(ImmutableMap.of());
+    private ThriftTypeRenderer typeRenderer;
     private List<ThriftType> thriftTypes = new CopyOnWriteArrayList<>();
     private List<ThriftServiceMetadata> thriftServices = new CopyOnWriteArrayList<>();
     private boolean recursive;
@@ -102,9 +102,9 @@ public class ThriftIdlGenerator
     {
         this.classLoader = requireNonNull(classLoader, "classLoader is null");
 
-        Monitor monitor = createMonitor(config.getErrorLogger(), config.getWarningLogger());
-        this.catalog = new ThriftCatalog(monitor);
+        this.catalog = new ThriftCatalog(createMonitor(config.getErrorLogger(), config.getWarningLogger()));
         this.codecManager = new ThriftCodecManager(catalog);
+        this.typeRenderer = new ThriftTypeRenderer(ImmutableMap.of(), catalog);
 
         this.verboseLogger = config.getVerboseLogger();
         String defaultPackage = config.getDefaultPackage();
@@ -443,7 +443,7 @@ public class ThriftIdlGenerator
             includesBuilder.add(filename);
             typesBuilder.put(type, getNameWithoutExtension(filename));
         }
-        typeRenderer = new ThriftTypeRenderer(typesBuilder.build());
+        typeRenderer = new ThriftTypeRenderer(typesBuilder.build(), catalog);
         return renderThriftIdl(namespaces, includesBuilder.build(), thriftTypes, thriftServices, typeRenderer);
     }
 

--- a/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftTypeRenderer.java
+++ b/drift/drift-idl-generator/src/main/java/com/facebook/drift/idl/generator/ThriftTypeRenderer.java
@@ -15,22 +15,35 @@
  */
 package com.facebook.drift.idl.generator;
 
+import com.facebook.drift.codec.metadata.ReflectionHelper;
+import com.facebook.drift.codec.metadata.ThriftCatalog;
 import com.facebook.drift.codec.metadata.ThriftType;
 import com.google.common.collect.ImmutableMap;
 
+import java.lang.reflect.Type;
 import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
 
 public class ThriftTypeRenderer
 {
     private final Map<ThriftType, String> typeNames;
+    private final ThriftCatalog catalog;
 
-    public ThriftTypeRenderer(Map<ThriftType, String> typeNames)
+    public ThriftTypeRenderer(Map<ThriftType, String> typeNames, ThriftCatalog catalog)
     {
         this.typeNames = ImmutableMap.copyOf(typeNames);
+        this.catalog = requireNonNull(catalog, "catalog is null");
     }
 
     public String toString(ThriftType type)
     {
+        if (ReflectionHelper.isOptional(type.getJavaType())) {
+            Type unwrappedJavaType = ReflectionHelper.getOptionalType(type.getJavaType());
+            ThriftType thriftType = catalog.getThriftType(unwrappedJavaType);
+            return toString(thriftType);
+        }
+
         switch (type.getProtocolType()) {
             case BOOL:
                 return "bool";

--- a/drift/drift-idl-generator/src/test/java/com/facebook/drift/idl/generator/OptionalField.java
+++ b/drift/drift-idl-generator/src/test/java/com/facebook/drift/idl/generator/OptionalField.java
@@ -45,4 +45,10 @@ public class OptionalField
 
     @ThriftField(value = 6)
     public OptionalDouble primitiveOptionalDouble;
+
+    @ThriftField(value = 7)
+    public Optional<Point> optionalPoint;
+
+    @ThriftField(value = 8)
+    public Optional<DriftResultCode> optionalDriftResultCode;
 }

--- a/drift/drift-idl-generator/src/test/resources/expected/optional.txt
+++ b/drift/drift-idl-generator/src/test/resources/expected/optional.txt
@@ -1,3 +1,23 @@
+enum Result {
+  OK = 0,
+  TRY_LATER = 1,
+}
+
+/**
+ * Two dimensional point.
+ */
+struct Point {
+  1: required i32 x;
+  2: required i32 y;
+
+  /**
+   * Info about the point
+   */
+  3: optional string comment;
+
+  4: optional i32 tag;
+}
+
 struct OptionalField {
   1: optional string optionalString;
   2: optional i64 optionalLong;
@@ -5,4 +25,6 @@ struct OptionalField {
   4: optional i32 primitiveOptionalInt;
   5: optional i64 primitiveOptionalLong;
   6: double primitiveOptionalDouble;
+  7: optional Point optionalPoint;
+  8: optional Result optionalDriftResultCode;
 }


### PR DESCRIPTION
1. For optional user-defined class, the metadata for it looks like 
```
ThriftType{
protocolType=STRUCT,
javaType=java.util.Optional<com.facebook.drift.idl.generator.TreeNode>, 
valueTypeReference=Resolved reference to 
    ThriftType{
        protocolType=STRUCT, 
        javaType=class com.facebook.drift.idl.generator.TreeNode, 
        structMetadata=com.facebook.drift.idl.generator.TreeNode
    }
}
```

To print it out while generating idl file, we need to unwrap it.
2. This also include the change from #112 which will be cleared out after it gets merged.