### PR TITLE
Explicitly set the netty SSL Provider to JDK

### DIFF
--- a/drift/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/ssl/ReloadableSslContext.java
+++ b/drift/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/ssl/ReloadableSslContext.java
@@ -25,6 +25,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBeh
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 
 import java.io.File;
 import java.io.IOException;
@@ -136,6 +137,7 @@ public final class ReloadableSslContext
                 // it should respond with a no_application_protocol alert and fail the TLS handshake.
                 sslContextBuilder.applicationProtocolConfig(new ApplicationProtocolConfig(
                         Protocol.ALPN, SelectorFailureBehavior.FATAL_ALERT, SelectedListenerFailureBehavior.FATAL_ALERT, new String[] {"thrift"}));
+                sslContextBuilder.sslProvider(SslProvider.JDK);
                 sslContext.set(new SslContextHolder(sslContextBuilder.build()));
             }
         }


### PR DESCRIPTION
This code uses the FATAL_ALERT failure behavior, which is only supported by the JDK ssl provider. However, if no SSL Provider is set, it is environment dependent whether the JDK or OpenSSL provider is used. This change Explicitly sets the ssl provider to JDK.

This fixes an issue where servers might fail on start up in ReferenceCountedOpenSslContext with "OpenSSL provider does not support FATAL_ALERT behavior" if they get created with OPEN_SSL as the provider.

Netty code pointers:
https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java#L420 https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java#L777 https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/ssl/SslContext.java#L832 https://github.com/netty/netty/blob/4.1/handler/src/main/java/io/netty/handler/ssl/SslContext.java#L127-L135