### PR TITLE
Downgrade guice to 6.0.0

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -54,6 +54,12 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/bootstrap/src/test/java/com/facebook/airlift/bootstrap/BarProvider.java
+++ b/bootstrap/src/test/java/com/facebook/airlift/bootstrap/BarProvider.java
@@ -2,7 +2,8 @@ package com.facebook.airlift.bootstrap;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 public class BarProvider
         implements Provider<BarInstance>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>

--- a/configuration/src/main/java/com/facebook/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/com/facebook/airlift/configuration/ConfigurationFactory.java
@@ -40,11 +40,12 @@ import com.google.inject.spi.InstanceBinding;
 import com.google.inject.spi.Message;
 import com.google.inject.spi.ProviderInstanceBinding;
 import jakarta.annotation.Nullable;
-import jakarta.inject.Provider;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.hibernate.validator.HibernateValidator;
+
+import javax.inject.Provider;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;

--- a/dbpool/pom.xml
+++ b/dbpool/pom.xml
@@ -58,6 +58,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/dbpool/src/main/java/com/facebook/airlift/dbpool/H2EmbeddedDataSourceModule.java
+++ b/dbpool/src/main/java/com/facebook/airlift/dbpool/H2EmbeddedDataSourceModule.java
@@ -23,9 +23,9 @@ import com.google.inject.Module;
 import com.google.inject.ProvisionException;
 import com.google.inject.Scopes;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import org.weakref.jmx.guice.MBeanModule;
 
+import javax.inject.Provider;
 import javax.sql.DataSource;
 
 import java.lang.annotation.Annotation;

--- a/dbpool/src/main/java/com/facebook/airlift/dbpool/MySqlDataSourceModule.java
+++ b/dbpool/src/main/java/com/facebook/airlift/dbpool/MySqlDataSourceModule.java
@@ -23,9 +23,9 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import org.weakref.jmx.guice.MBeanModule;
 
+import javax.inject.Provider;
 import javax.sql.DataSource;
 
 import java.lang.annotation.Annotation;

--- a/dbpool/src/main/java/com/facebook/airlift/dbpool/PostgreSqlDataSourceModule.java
+++ b/dbpool/src/main/java/com/facebook/airlift/dbpool/PostgreSqlDataSourceModule.java
@@ -23,9 +23,9 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import org.weakref.jmx.guice.MBeanModule;
 
+import javax.inject.Provider;
 import javax.sql.DataSource;
 
 import java.lang.annotation.Annotation;

--- a/discovery-server/pom.xml
+++ b/discovery-server/pom.xml
@@ -172,6 +172,11 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ReplicatedStoreModule.java
+++ b/discovery-server/src/main/java/com/facebook/airlift/discovery/store/ReplicatedStoreModule.java
@@ -28,8 +28,9 @@ import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import org.weakref.jmx.MBeanExporter;
+
+import javax.inject.Provider;
 
 import java.lang.annotation.Annotation;
 import java.time.ZonedDateTime;
@@ -103,7 +104,7 @@ public class ReplicatedStoreModule
 
     @ThreadSafe
     private static class ReplicatorProvider
-            implements jakarta.inject.Provider<Replicator>
+            implements Provider<Replicator>
     {
         private final String name;
         private final Key<? extends LocalStore> localStoreKey;

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -77,6 +77,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/discovery/src/main/java/com/facebook/airlift/discovery/client/DiscoveryBinder.java
+++ b/discovery/src/main/java/com/facebook/airlift/discovery/client/DiscoveryBinder.java
@@ -21,7 +21,8 @@ import com.google.inject.Key;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;

--- a/discovery/src/main/java/com/facebook/airlift/discovery/client/DiscoveryModule.java
+++ b/discovery/src/main/java/com/facebook/airlift/discovery/client/DiscoveryModule.java
@@ -21,8 +21,9 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import jakarta.annotation.PreDestroy;
-import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
+
+import javax.inject.Provider;
 
 import java.net.URI;
 import java.util.concurrent.ScheduledExecutorService;

--- a/discovery/src/main/java/com/facebook/airlift/discovery/client/HttpServiceSelectorProvider.java
+++ b/discovery/src/main/java/com/facebook/airlift/discovery/client/HttpServiceSelectorProvider.java
@@ -18,7 +18,8 @@ package com.facebook.airlift.discovery.client;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import static com.facebook.airlift.discovery.client.ServiceTypes.serviceType;
 import static java.util.Objects.requireNonNull;

--- a/discovery/src/main/java/com/facebook/airlift/discovery/client/ServiceSelectorProvider.java
+++ b/discovery/src/main/java/com/facebook/airlift/discovery/client/ServiceSelectorProvider.java
@@ -18,7 +18,8 @@ package com.facebook.airlift.discovery.client;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import static com.facebook.airlift.discovery.client.ServiceTypes.serviceType;
 import static java.util.Objects.requireNonNull;

--- a/discovery/src/test/java/com/facebook/airlift/discovery/client/TestDiscoveryBinder.java
+++ b/discovery/src/test/java/com/facebook/airlift/discovery/client/TestDiscoveryBinder.java
@@ -27,8 +27,9 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
-import jakarta.inject.Provider;
 import org.testng.annotations.Test;
+
+import javax.inject.Provider;
 
 import java.util.Map;
 import java.util.Set;

--- a/drift/drift-client/pom.xml
+++ b/drift/drift-client/pom.xml
@@ -82,6 +82,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/drift/drift-client/src/main/java/com/facebook/drift/client/guice/AbstractAnnotatedProvider.java
+++ b/drift/drift-client/src/main/java/com/facebook/drift/client/guice/AbstractAnnotatedProvider.java
@@ -17,7 +17,8 @@ package com.facebook.drift.client.guice;
 
 import com.google.inject.Injector;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.lang.annotation.Annotation;
 import java.util.Objects;

--- a/drift/drift-client/src/main/java/com/facebook/drift/client/guice/DriftClientBinder.java
+++ b/drift/drift-client/src/main/java/com/facebook/drift/client/guice/DriftClientBinder.java
@@ -40,9 +40,10 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import org.weakref.jmx.MBeanExporter;
+
+import javax.inject.Provider;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;

--- a/drift/drift-codec/pom.xml
+++ b/drift/drift-codec/pom.xml
@@ -74,8 +74,8 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/drift/drift-codec/src/main/java/com/facebook/drift/codec/guice/ThriftCodecBinder.java
+++ b/drift/drift-codec/src/main/java/com/facebook/drift/codec/guice/ThriftCodecBinder.java
@@ -24,7 +24,8 @@ import com.google.inject.Key;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.internal.MoreTypes.ParameterizedTypeImpl;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.lang.reflect.Type;
 import java.util.List;

--- a/drift/drift-server/pom.xml
+++ b/drift/drift-server/pom.xml
@@ -72,6 +72,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/drift/drift-server/src/main/java/com/facebook/drift/server/guice/DriftServerBinder.java
+++ b/drift/drift-server/src/main/java/com/facebook/drift/server/guice/DriftServerBinder.java
@@ -29,8 +29,9 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.multibindings.Multibinder;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import org.weakref.jmx.MBeanExporter;
+
+import javax.inject.Provider;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;

--- a/drift/drift-transport-netty/pom.xml
+++ b/drift/drift-transport-netty/pom.xml
@@ -124,6 +124,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
             <optional>true</optional>

--- a/drift/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyClientModule.java
+++ b/drift/drift-transport-netty/src/main/java/com/facebook/drift/transport/netty/client/DriftNettyClientModule.java
@@ -28,7 +28,8 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.concurrent.EventExecutorGroup;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.lang.annotation.Annotation;
 

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -108,6 +108,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/http-client/src/main/java/com/facebook/airlift/http/client/HttpClientModule.java
+++ b/http-client/src/main/java/com/facebook/airlift/http/client/HttpClientModule.java
@@ -27,7 +27,8 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;

--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -87,6 +87,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
         </dependency>

--- a/http-server/src/main/java/com/facebook/airlift/http/server/HashLoginServiceProvider.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HashLoginServiceProvider.java
@@ -16,9 +16,10 @@
 package com.facebook.airlift.http.server;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.util.resource.PathResourceFactory;
+
+import javax.inject.Provider;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 

--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerProvider.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerProvider.java
@@ -23,11 +23,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import jakarta.annotation.Nullable;
-import jakarta.inject.Provider;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.security.LoginService;
 
+import javax.inject.Provider;
 import javax.management.MBeanServer;
 
 import java.util.Map;

--- a/jmx-http-rpc/pom.xml
+++ b/jmx-http-rpc/pom.xml
@@ -53,6 +53,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/jmx-http-rpc/src/main/java/com/facebook/airlift/jmx/http/rpc/JmxHttpRpcModule.java
+++ b/jmx-http-rpc/src/main/java/com/facebook/airlift/jmx/http/rpc/JmxHttpRpcModule.java
@@ -28,8 +28,9 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import jakarta.servlet.Servlet;
+
+import javax.inject.Provider;
 
 import java.lang.annotation.Annotation;
 import java.net.URI;

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/jmx/src/main/java/com/facebook/airlift/jmx/JmxModule.java
+++ b/jmx/src/main/java/com/facebook/airlift/jmx/JmxModule.java
@@ -20,8 +20,8 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 
+import javax.inject.Provider;
 import javax.management.MBeanServer;
 
 import java.lang.management.ManagementFactory;

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -77,6 +77,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/json/src/main/java/com/facebook/airlift/json/JsonCodecFactory.java
+++ b/json/src/main/java/com/facebook/airlift/json/JsonCodecFactory.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.lang.reflect.Type;
 import java.util.List;

--- a/json/src/main/java/com/facebook/airlift/json/JsonCodecProvider.java
+++ b/json/src/main/java/com/facebook/airlift/json/JsonCodecProvider.java
@@ -16,7 +16,8 @@
 package com.facebook.airlift.json;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.lang.reflect.Type;
 

--- a/json/src/main/java/com/facebook/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/com/facebook/airlift/json/ObjectMapperProvider.java
@@ -34,7 +34,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.util.HashSet;
 import java.util.Map;

--- a/json/src/main/java/com/facebook/airlift/json/smile/SmileCodecFactory.java
+++ b/json/src/main/java/com/facebook/airlift/json/smile/SmileCodecFactory.java
@@ -18,7 +18,8 @@ import com.google.common.annotations.Beta;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.lang.reflect.Type;
 import java.util.List;

--- a/json/src/main/java/com/facebook/airlift/json/smile/SmileCodecProvider.java
+++ b/json/src/main/java/com/facebook/airlift/json/smile/SmileCodecProvider.java
@@ -14,7 +14,8 @@
 package com.facebook.airlift.json.smile;
 
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
+
+import javax.inject.Provider;
 
 import java.lang.reflect.Type;
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>105</version>
+        <version>106</version>
     </parent>
 
     <inceptionYear>2010</inceptionYear>


### PR DESCRIPTION
Initially guice was upgraded to 7.0.0 as part of the jetty upgrade. However, guice 7.0.0 doesn't support javax classes, so it makes it complicated to integrate modules where some need to support java 8 (and use javax) and some need to support the jetty upgrade.  Guice 6.0.0 supports both javax and jakarta namespaces except for the toProvider() interface.  So all of the Providers were changed back to using javax.inject.Provider. All other jakarta migrations remain.