### PR TITLE
Fix the validation errors when publishing release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
             -DkeepStagingRepositoryOnFailure=true \
             -DstagingProgressTimeoutMinutes=10 \
             -DskipTests \
-            -Poss-release \
-            -Pdeploy-to-ossrh
+            -Poss-release
 
       - name: Push changes and tags
         run: |

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -3,6 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>discovery</artifactId>
     <packaging>jar</packaging>
+    <name>discovery</name>
 
     <parent>
         <groupId>com.facebook.airlift</groupId>

--- a/drift/drift-api/pom.xml
+++ b/drift/drift-api/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>drift-api</artifactId>
+    <name>drift-api</name>
     <description>Drift annotations and exceptions for use in Thrift interfaces and types</description>
     <packaging>jar</packaging>
 

--- a/drift/drift-codec-utils/pom.xml
+++ b/drift/drift-codec-utils/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>drift-codec-utils</artifactId>
+    <name>drift-codec-utils</name>
     <description>Default codecs for common data structures</description>
     <packaging>jar</packaging>
 

--- a/drift/drift-codec/pom.xml
+++ b/drift/drift-codec/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>drift-codec</artifactId>
+    <name>drift-codec</name>
     <description>Annotation based encoder and decoder for Thrift</description>
     <packaging>jar</packaging>
 

--- a/drift/drift-idl-generator/pom.xml
+++ b/drift/drift-idl-generator/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>drift-idl-generator</artifactId>
+    <name>drift-idl-generator</name>
     <description>Generate Thrift IDL from Drift annotated classes</description>
     <packaging>jar</packaging>
 

--- a/drift/drift-javadoc/pom.xml
+++ b/drift/drift-javadoc/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>drift-javadoc</artifactId>
+    <name>drift-javadoc</name>
     <description>Annotation processor to store the Javadoc of Drift classes</description>
     <packaging>jar</packaging>
 

--- a/drift/drift-maven-plugin/pom.xml
+++ b/drift/drift-maven-plugin/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>drift-maven-plugin</artifactId>
+    <name>drift-maven-plugin</name>
     <description>Maven plugin for Drift</description>
     <packaging>maven-plugin</packaging>
 

--- a/drift/drift-protocol/pom.xml
+++ b/drift/drift-protocol/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>drift-protocol</artifactId>
+    <name>drift-protocol</name>
     <description>Core classes for Drift</description>
     <packaging>jar</packaging>
 

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event</artifactId>
+    <name>event</name>
     <packaging>jar</packaging>
 
     <parent>

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>http-client</artifactId>
+    <name>http-client</name>
     <packaging>jar</packaging>
 
     <parent>

--- a/http-utils/pom.xml
+++ b/http-utils/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>http-utils</artifactId>
+    <name>http-utils</name>
     <packaging>jar</packaging>
 
     <parent>

--- a/jmx-http-rpc/pom.xml
+++ b/jmx-http-rpc/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jmx-http-rpc</artifactId>
+    <name>jmx-http-rpc</name>
     <packaging>jar</packaging>
 
     <parent>

--- a/jmx-http/pom.xml
+++ b/jmx-http/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jmx-http</artifactId>
+    <name>jmx-http</name>
     <packaging>jar</packaging>
 
     <parent>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>json</artifactId>
+    <name>json</name>
     <packaging>jar</packaging>
 
     <parent>

--- a/trace-token/pom.xml
+++ b/trace-token/pom.xml
@@ -2,6 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>trace-token</artifactId>
+    <name>trace-token</name>
     <packaging>jar</packaging>
 
     <parent>


### PR DESCRIPTION
When publishing, there are errors:

```
[INFO] Waiting until Deployment 83863e53-5035-4997-8066-59831e3934a1 is validated
Error:  

Deployment 83863e53-5035-4997-8066-59831e3934a1 failed
pkg:maven/com.facebook.airlift/discovery@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift.drift/drift-codec-utils@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift/trace-token@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift/json@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift/http-utils@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift.drift/drift-protocol@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift/jmx-http@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift.drift/drift-javadoc@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift/jmx-http-rpc@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift/event@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift.drift/drift-maven-plugin@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift/http-client@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift.drift/drift-idl-generator@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift.drift/drift-codec@0.220:
 - Project name is missing

pkg:maven/com.facebook.airlift.drift/drift-api@0.220:
 - Project name is missing
```

Also a warning
```
Warning:  The requested profile "deploy-to-ossrh" could not be activated because it does not exist.
```