### PR TITLE
Add suppport for configuring http compliance violations

### DIFF
--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpComplianceViolation.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpComplianceViolation.java
@@ -1,0 +1,33 @@
+package com.facebook.airlift.http.server;
+
+import org.eclipse.jetty.http.HttpCompliance.Violation;
+
+import static java.util.Objects.requireNonNull;
+
+public enum HttpComplianceViolation
+{
+    CASE_SENSITIVE_FIELD_NAME(Violation.CASE_SENSITIVE_FIELD_NAME),
+    CASE_INSENSITIVE_METHOD(Violation.CASE_INSENSITIVE_METHOD),
+    HTTP_0_9(Violation.HTTP_0_9),
+    MULTILINE_FIELD_VALUE(Violation.MULTILINE_FIELD_VALUE),
+    MULTIPLE_CONTENT_LENGTHS(Violation.MULTIPLE_CONTENT_LENGTHS),
+    TRANSFER_ENCODING_WITH_CONTENT_LENGTH(Violation.TRANSFER_ENCODING_WITH_CONTENT_LENGTH),
+    WHITESPACE_AFTER_FIELD_NAME(Violation.WHITESPACE_AFTER_FIELD_NAME),
+    NO_COLON_AFTER_FIELD_NAME(Violation.NO_COLON_AFTER_FIELD_NAME),
+    DUPLICATE_HOST_HEADERS(Violation.DUPLICATE_HOST_HEADERS),
+    UNSAFE_HOST_HEADER(Violation.UNSAFE_HOST_HEADER),
+    MISMATCHED_AUTHORITY(Violation.MISMATCHED_AUTHORITY);
+
+    private final Violation httpComplianceViolation;
+
+    HttpComplianceViolation(Violation httpComplianceViolation)
+    {
+        this.httpComplianceViolation = requireNonNull(httpComplianceViolation, "httpComplianceViolation is null");
+    }
+
+    public Violation getHttpComplianceViolation()
+
+    {
+        return httpComplianceViolation;
+    }
+}

--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServer.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.jmx.MBeanContainer;
@@ -147,6 +148,13 @@ public class HttpServer
         baseHttpConfiguration.setSendServerVersion(false);
         baseHttpConfiguration.setSendXPoweredBy(false);
         baseHttpConfiguration.setUriCompliance(config.getUriComplianceMode().getUriCompliance());
+        if (!config.getHttpComplianceViolations().isEmpty()) {
+            HttpCompliance.Violation[] jettyViolations = config.getHttpComplianceViolations().stream()
+                    .map(HttpComplianceViolation::getHttpComplianceViolation)
+                    .toArray(HttpCompliance.Violation[]::new);
+            HttpCompliance customCompliance = baseHttpConfiguration.getHttpCompliance().with("customViolations", jettyViolations);
+            baseHttpConfiguration.setHttpCompliance(customCompliance);
+        }
         if (config.getMaxRequestHeaderSize() != null) {
             baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
         }

--- a/http-server/src/test/java/com/facebook/airlift/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/com/facebook/airlift/http/server/TestHttpServerConfig.java
@@ -89,7 +89,8 @@ public class TestHttpServerConfig
                 .setDefaultAllowedRoles("")
                 .setAllowUnsecureRequestsInAuthorizer(false)
                 .setSniHostCheck(true)
-                .setUriComplianceMode(UriCompliance.DEFAULT));
+                .setUriComplianceMode(UriCompliance.DEFAULT)
+                .setHttpComplianceViolations(""));
     }
 
     @Test
@@ -147,6 +148,7 @@ public class TestHttpServerConfig
                 .put("http-server.authorization.allow-unsecured-requests", "true")
                 .put("http-server.https.sni-host-check", "false")
                 .put("http-server.uri-compliance.mode", "LEGACY")
+                .put("http-server.http-compliance.violations", "UNSAFE_HOST_HEADER,MISMATCHED_AUTHORITY")
                 .build();
 
         HttpServerConfig expected = new HttpServerConfig()
@@ -200,7 +202,8 @@ public class TestHttpServerConfig
                 .setDefaultAllowedRoles("user, internal, admin")
                 .setAllowUnsecureRequestsInAuthorizer(true)
                 .setSniHostCheck(false)
-                .setUriComplianceMode(UriCompliance.LEGACY);
+                .setUriComplianceMode(UriCompliance.LEGACY)
+                .setHttpComplianceViolations("UNSAFE_HOST_HEADER,MISMATCHED_AUTHORITY");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }
@@ -209,5 +212,14 @@ public class TestHttpServerConfig
     {
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         return Arrays.asList(sslContextFactory.getExcludeCipherSuites());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Invalid value for http compliance violation: INVALID_VALUE. Permitted values are " +
+                    "\\[CASE_SENSITIVE_FIELD_NAME, CASE_INSENSITIVE_METHOD, HTTP_0_9, MULTILINE_FIELD_VALUE, MULTIPLE_CONTENT_LENGTHS, TRANSFER_ENCODING_WITH_CONTENT_LENGTH, " +
+                    "WHITESPACE_AFTER_FIELD_NAME, NO_COLON_AFTER_FIELD_NAME, DUPLICATE_HOST_HEADERS, UNSAFE_HOST_HEADER, MISMATCHED_AUTHORITY\\]")
+    public void testInvalidHttpComplianceViolation()
+    {
+        new HttpServerConfig().setHttpComplianceViolations("INVALID_VALUE");
     }
 }


### PR DESCRIPTION
The jetty 12 upgrade includes stricter enforcement of http compliance violations.  Users may want to allow certain violations while their clients adapt to the new requirements.