### PR TITLE
bug(listener): Add null check for content before updating response size

### DIFF
--- a/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerChannelListener.java
+++ b/http-server/src/main/java/com/facebook/airlift/http/server/HttpServerChannelListener.java
@@ -73,8 +73,10 @@ public class HttpServerChannelListener
         if (request.getAttribute(RESPONSE_CONTENT_SIZES_ATTRIBUTE) == null) {
             request.setAttribute(RESPONSE_CONTENT_SIZES_ATTRIBUTE, new AtomicLong(0L));
         }
-        AtomicLong responseSize = (AtomicLong) request.getAttribute(RESPONSE_CONTENT_SIZES_ATTRIBUTE);
-        responseSize.addAndGet(content.remaining());
+        if (content != null) {
+            AtomicLong responseSize = (AtomicLong) request.getAttribute(RESPONSE_CONTENT_SIZES_ATTRIBUTE);
+            responseSize.addAndGet((long) content.remaining());
+        }
     }
 
     @Override


### PR DESCRIPTION
Sometimes Presto can run into this error:
```2025-10-16T15:07:06.270+0545	INFO	http-worker-152	org.eclipse.jetty.server.handler.EventsHandler	Error firing onResponseWrite
java.lang.NullPointerException: Cannot invoke "java.nio.ByteBuffer.remaining()" because "content" is null
	at com.facebook.airlift.http.server.HttpServerChannelListener.onResponseWrite(HttpServerChannelListener.java:77)
	at org.eclipse.jetty.server.handler.EventsHandler.notifyOnResponseWrite(EventsHandler.java:149)
	at org.eclipse.jetty.server.handler.EventsHandler$EventsResponse.write(EventsHandler.java:352)
	at org.eclipse.jetty.server.Response$Wrapper.write(Response.java:768)
	at org.eclipse.jetty.server.handler.EventsHandler$EventsResponse.write(EventsHandler.java:353)
	at org.eclipse.jetty.server.Response$Wrapper.write(Response.java:768)
	at org.eclipse.jetty.server.handler.ContextResponse.write(ContextResponse.java:56)
	at org.eclipse.jetty.ee10.servlet.ServletContextResponse.write(ServletContextResponse.java:288)
	at org.eclipse.jetty.server.Response$Wrapper.write(Response.java:768)
	at org.eclipse.jetty.server.handler.gzip.GzipResponseAndCallback.commit(GzipResponseAndCallback.java:191)
	at org.eclipse.jetty.server.handler.gzip.GzipResponseAndCallback.write(GzipResponseAndCallback.java:132)
	at org.eclipse.jetty.server.handler.gzip.GzipResponseAndCallback.succeeded(GzipResponseAndCallback.java:97)
	at org.eclipse.jetty.ee10.servlet.ServletChannel.onCompleted(ServletChannel.java:760)
	at org.eclipse.jetty.ee10.servlet.ServletChannel.handle(ServletChannel.java:426)
	at org.eclipse.jetty.ee10.servlet.ServletHandler.handle(ServletHandler.java:469)
	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:611)
	at org.eclipse.jetty.server.handler.ContextHandler.handle(ContextHandler.java:1064)
	at org.eclipse.jetty.server.Handler$Sequence.handle(Handler.java:805)
	at org.eclipse.jetty.server.Handler$Wrapper.handle(Handler.java:740)
	at org.eclipse.jetty.server.handler.EventsHandler.handle(EventsHandler.java:81)
	at org.eclipse.jetty.server.Handler$Wrapper.handle(Handler.java:740)
	at org.eclipse.jetty.server.handler.EventsHandler.handle(EventsHandler.java:81)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:151)
	at org.eclipse.jetty.server.Server.handle(Server.java:182)
	at org.eclipse.jetty.server.internal.HttpChannelState$HandlerInvoker.run(HttpChannelState.java:662)
	at org.eclipse.jetty.server.internal.HttpConnection.onFillable(HttpConnection.java:416)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:322)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:99)
	at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:480)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:443)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:293)
	at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:201)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:311)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:979)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1209)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1164)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

This PR will resolve it by adding a null check.