### PR TITLE
chore(deps): Bump jetty from 12.0.29 to 12.0.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <dep.airlift.version>0.217-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${project.version}</dep.packaging.version>
-        <dep.jetty.version>12.0.29</dep.jetty.version>
+        <dep.jetty.version>12.0.34</dep.jetty.version>
         <dep.jersey.version>4.0.0-M2</dep.jersey.version>
         <dep.drift.version>0.230-SNAPSHOT</dep.drift.version>
     </properties>


### PR DESCRIPTION
Upgrade jetty version from 12.0.29 to 12.0.32 to address CVE-2025-11143, CVE-2026-1605 and CVE-2026-2332.. 