### PR TITLE
fix: Add jaxb-runtime library to avoid NoClassDefFoundError

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -87,6 +87,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -444,6 +444,22 @@
             </dependency>
 
             <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>2.3.4</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.activation</groupId>
+                        <artifactId>jakarta.activation</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-common</artifactId>
                 <version>${dep.jersey.version}</version>


### PR DESCRIPTION
## Description
Add `org.glassfish.jaxb:jaxb-runtime` library to avoid `NoClassDefFoundError`


```
WARN    http-worker-2412    org.eclipse.jetty.server.HttpChannel    /
javax.servlet.ServletException: javax.servlet.ServletException: A MultiException has 4 exceptions.  They are:
1. java.lang.NoClassDefFoundError: com/sun/istack/FinalArrayList
2. java.lang.IllegalStateException: Unable to perform operation: create on org.glassfish.jersey.server.wadl.internal.WadlApplicationContextImpl
3. java.lang.IllegalArgumentException: While attempting to resolve the dependencies of org.glassfish.jersey.server.wadl.processor.WadlModelProcessor$OptionsHandler errors were found
4. java.lang.IllegalStateException: Unable to perform operation: resolve on org.glassfish.jersey.server.wadl.processor.WadlModelProcessor$OptionsHandler

    at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:162)
    at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:181)
    at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:59)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
    at org.eclipse.jetty.server.Server.handle(Server.java:512)
    at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487)
    at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732)
    at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479)
    at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
    at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
    at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
    at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
    at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
    at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
    at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
    at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
    at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
    at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: javax.servlet.ServletException: A MultiException has 4 exceptions.  They are:
1. java.lang.NoClassDefFoundError: com/sun/istack/FinalArrayList
2. java.lang.IllegalStateException: Unable to perform operation: create on org.glassfish.jersey.server.wadl.internal.WadlApplicationContextImpl
3. java.lang.IllegalArgumentException: While attempting to resolve the dependencies of org.glassfish.jersey.server.wadl.processor.WadlModelProcessor$OptionsHandler errors were found
4. java.lang.IllegalStateException: Unable to perform operation: resolve on org.glassfish.jersey.server.wadl.processor.WadlModelProcessor$OptionsHandler
```


## Release Notes

```
== RELEASE NOTES ==

General Changes
* Add org.glassfish.jaxb:jaxb-runtime library to avoid NoClassDefFoundError.
```