### PR TITLE
chore(deps): Revert - Upgrade jol-core to latest

### DIFF
--- a/drift/pom.xml
+++ b/drift/pom.xml
@@ -343,7 +343,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.5.1</version>
                     <executions>
                         <execution>
                             <id>help-mojo</id>
@@ -357,7 +357,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.1.0</version>
                 </plugin>
 
                 <plugin>

--- a/http-client/src/test/java/com/facebook/airlift/http/client/jetty/TestJettyHttpsClient.java
+++ b/http-client/src/test/java/com/facebook/airlift/http/client/jetty/TestJettyHttpsClient.java
@@ -87,7 +87,7 @@ public class TestJettyHttpsClient
         super.testConnectTimeout();
     }
 
-    @Test(expectedExceptions = IOException.class)
+    @Test(expectedExceptions = {IOException.class})
     public void testCertHostnameMismatch()
             throws Exception
     {

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>109</version>
+        <version>108</version>
     </parent>
 
     <inceptionYear>2010</inceptionYear>

--- a/stats/pom.xml
+++ b/stats/pom.xml
@@ -72,13 +72,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
-            <version>0.45</version>
         </dependency>
 
         <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
-            <version>0.17</version>
+            <version>0.2</version>
         </dependency>
 
         <!-- for testing -->

--- a/stats/src/main/java/com/facebook/airlift/stats/QuantileDigest.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/QuantileDigest.java
@@ -58,7 +58,7 @@ import static java.lang.String.format;
 public class QuantileDigest
 {
     private static final int MAX_BITS = 64;
-    private static final long QUANTILE_DIGEST_SIZE = ClassLayout.parseClass(QuantileDigest.class).instanceSize();
+    private static final int QUANTILE_DIGEST_SIZE = ClassLayout.parseClass(QuantileDigest.class).instanceSize();
 
     // needs to be such that Math.exp(alpha * seconds) does not grow too big
     static final long RESCALE_THRESHOLD_SECONDS = 50;

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/DenseHll.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/DenseHll.java
@@ -46,7 +46,7 @@ final class DenseHll
     private static final int MAX_DELTA = (1 << BITS_PER_BUCKET) - 1;
     private static final int BUCKET_MASK = (1 << BITS_PER_BUCKET) - 1;
 
-    private static final long DENSE_INSTANCE_SIZE = ClassLayout.parseClass(DenseHll.class).instanceSize();
+    private static final int DENSE_INSTANCE_SIZE = ClassLayout.parseClass(DenseHll.class).instanceSize();
     private static final int OVERFLOW_GROW_INCREMENT = 5;
 
     private final byte indexBitLength;
@@ -148,9 +148,9 @@ final class DenseHll
     }
 
     @Override
-    public long estimatedInMemorySize()
+    public int estimatedInMemorySize()
     {
-        return (DENSE_INSTANCE_SIZE +
+        return (int) (DENSE_INSTANCE_SIZE +
                 SizeOf.sizeOf(deltas) +
                 SizeOf.sizeOf(overflowBuckets) +
                 SizeOf.sizeOf(overflowValues));

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/HllInstance.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/HllInstance.java
@@ -26,7 +26,7 @@ interface HllInstance
 
     int getIndexBitLength();
 
-    long estimatedInMemorySize();
+    int estimatedInMemorySize();
 
     int estimatedSerializedSize();
 

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/HyperLogLog.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/HyperLogLog.java
@@ -24,7 +24,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 public class HyperLogLog
 {
-    private static final long INSTANCE_SIZE = ClassLayout.parseClass(HyperLogLog.class).instanceSize();
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(HyperLogLog.class).instanceSize();
     private static final int MAX_NUMBER_OF_BUCKETS = 65536;
     private HllInstance instance;
 
@@ -106,7 +106,7 @@ public class HyperLogLog
         instance.eachBucket(listener);
     }
 
-    public long estimatedInMemorySize()
+    public int estimatedInMemorySize()
     {
         return instance.estimatedInMemorySize() + INSTANCE_SIZE;
     }

--- a/stats/src/main/java/com/facebook/airlift/stats/cardinality/SparseHll.java
+++ b/stats/src/main/java/com/facebook/airlift/stats/cardinality/SparseHll.java
@@ -40,7 +40,7 @@ import static java.util.Comparator.comparingInt;
 final class SparseHll
         implements HllInstance
 {
-    private static final long SPARSE_INSTANCE_SIZE = ClassLayout.parseClass(SparseHll.class).instanceSize();
+    private static final int SPARSE_INSTANCE_SIZE = ClassLayout.parseClass(SparseHll.class).instanceSize();
 
     // 6 bits to encode the number of zeros after the truncated hash
     // and be able to fit the encoded value in an integer
@@ -192,7 +192,7 @@ final class SparseHll
     }
 
     @Override
-    public long estimatedInMemorySize()
+    public int estimatedInMemorySize()
     {
         return SPARSE_INSTANCE_SIZE + toIntExact(sizeOf(entries));
     }

--- a/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestSparseHll.java
+++ b/stats/src/test/java/com/facebook/airlift/stats/cardinality/TestSparseHll.java
@@ -28,7 +28,7 @@ import static org.testng.Assert.assertEquals;
 
 public class TestSparseHll
 {
-    private static final long SPARSE_HLL_INSTANCE_SIZE = ClassLayout.parseClass(SparseHll.class).instanceSize();
+    private static final int SPARSE_HLL_INSTANCE_SIZE = ClassLayout.parseClass(SparseHll.class).instanceSize();
 
     @Test(dataProvider = "bits")
     public void testNumberOfZeros(int indexBitLength)


### PR DESCRIPTION
This reverts the jol-core update that broke old jdk compatibility: https://github.com/prestodb/presto/issues/27382