### PR TITLE
chore(deps): Bump jetty from 12.0.34 to 12.0.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <dep.airlift.version>0.217-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${project.version}</dep.packaging.version>
-        <dep.jetty.version>12.0.34</dep.jetty.version>
+        <dep.jetty.version>12.0.38</dep.jetty.version>
         <dep.jersey.version>4.0.0-M2</dep.jersey.version>
         <dep.drift.version>0.231-SNAPSHOT</dep.drift.version>
     </properties>


### PR DESCRIPTION
Upgrade jetty from 12.0.34 to 12.0.38 to address CVE-2026-10050 , CVE-2026-10051 , CVE-2026-6790 and CVE-2026-8384

OSS presto PR (using jitpack) for testing this change : https://github.com/prestodb/presto/pull/28307

Tag **0.231-jetty** : https://github.com/ShahimSharafudeen/airlift/tree/0.231-jetty

Airlift local build :

<img width="1728" height="1117" alt="Screenshot 2026-08-10 at 4 41 22 PM" src="https://github.com/user-attachments/assets/61e72ece-9f2d-4ad5-b187-1ba919473c06" />


Presto local build :

<img width="1454" height="1019" alt="Screenshot 2026-08-10 at 4 45 29 PM" src="https://github.com/user-attachments/assets/1f56c93d-6cd9-4c9a-b463-4d624bf4212a" />

Pesto CI test results :

<img width="1184" height="966" alt="image" src="https://github.com/user-attachments/assets/4b2edb92-c334-41e4-9046-7da532320f13" />


